### PR TITLE
[codex] Fix Discord @everyone ping for Bunny webhook announcements

### DIFF
--- a/app/api/webhooks/bunny/route.ts
+++ b/app/api/webhooks/bunny/route.ts
@@ -23,6 +23,13 @@ function getStringProp(value: unknown, key: string): string | null {
   return typeof v === 'string' ? v : null
 }
 
+function getBooleanProp(value: unknown, key: string): boolean | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const v = record[key]
+  return typeof v === 'boolean' ? v : null
+}
+
 export async function POST(req: Request) {
   try {
     let body: unknown
@@ -97,6 +104,20 @@ export async function POST(req: Request) {
     const courseForText = playlistName ?? moduleName
     const videoUrl = `${baseUrl}/mentorship/modul/${moduleId}?video=${video.id}`
     const thumbnailUrl = `https://${BUNNY_CDN_HOST}/${video.bunnyGuid}/thumbnail.jpg`
+    const announcementContent = [
+      '@everyone',
+      `Moin zusammen, ich habe soeben ein neues Video (**${video.title}**) veröffentlicht.`,
+      `Ihr findet das Video in der **${courseForText}**.`,
+      '',
+      videoUrl,
+      '',
+      'Passt auf euch auf,',
+      'Petar',
+    ].join('\n')
+    const embedDescription = [
+      `Neue Lektion aus **${courseForText}**.`,
+      'Der Direktlink steht direkt im Text ueber dieser Vorschau.',
+    ].join('\n')
 
     let messageSent = false
 
@@ -117,13 +138,13 @@ export async function POST(req: Request) {
 
         const message = await sendDiscordChannelMessageWithAttachment({
           channelId,
-          content: '',
+          content: announcementContent,
           allowedMentions: { parse: ['everyone'] },
           embeds: [
             {
               title: `Neues Video: ${video.title}`,
               url: videoUrl,
-              description: `@everyone\n\nMoin zusammen, ich habe soeben ein neues Video veröffentlicht.\nIhr findet das Video in der **${courseForText}**.\n\n${videoUrl}\n\nPasst auf euch auf,\nPetar`,
+              description: embedDescription,
               color: 0x24fc35,
               image: { url: `attachment://${fileName}` },
               fields: [
@@ -146,25 +167,41 @@ export async function POST(req: Request) {
 
         messageSent = true
         const messageId = getStringProp(message, 'id')
+        const mentionEveryone = getBooleanProp(message, 'mention_everyone')
+
+        if (mentionEveryone !== true) {
+          console.warn('Bunny webhook: Discord announcement posted without mention_everyone ping.', {
+            videoId: video.id,
+            messageId,
+            channelId,
+          })
+        }
+
         await prisma.video.update({
           where: { id: video.id },
           data: { announcementMessageId: messageId },
         })
 
-        return NextResponse.json({ ok: true, action: 'announced', messageId, thumbnail: 'attached' })
+        return NextResponse.json({
+          ok: true,
+          action: 'announced',
+          messageId,
+          thumbnail: 'attached',
+          mentionEveryone: mentionEveryone === true,
+        })
       } catch (thumbErr) {
         console.warn('Bunny webhook: Thumbnail failed, sending without:', thumbErr)
 
         // Fallback: no thumbnail
         const message = await sendDiscordChannelMessage({
           channelId,
-          content: '',
+          content: announcementContent,
           allowedMentions: { parse: ['everyone'] },
           embeds: [
             {
               title: `Neues Video: ${video.title}`,
               url: videoUrl,
-              description: `@everyone\n\nMoin zusammen, ich habe soeben ein neues Video veröffentlicht.\nIhr findet das Video in der **${courseForText}**.\n\n${videoUrl}\n\nPasst auf euch auf,\nPetar`,
+              description: embedDescription,
               color: 0x2563eb,
               fields: [
                 ...(playlistName ? [{ name: 'Kurs', value: playlistName, inline: true }] : []),
@@ -181,12 +218,28 @@ export async function POST(req: Request) {
 
         messageSent = true
         const messageId = getStringProp(message, 'id')
+        const mentionEveryone = getBooleanProp(message, 'mention_everyone')
+
+        if (mentionEveryone !== true) {
+          console.warn('Bunny webhook: Discord announcement posted without mention_everyone ping.', {
+            videoId: video.id,
+            messageId,
+            channelId,
+          })
+        }
+
         await prisma.video.update({
           where: { id: video.id },
           data: { announcementMessageId: messageId },
         })
 
-        return NextResponse.json({ ok: true, action: 'announced', messageId, thumbnail: 'none' })
+        return NextResponse.json({
+          ok: true,
+          action: 'announced',
+          messageId,
+          thumbnail: 'none',
+          mentionEveryone: mentionEveryone === true,
+        })
       }
     } catch (err) {
       // Rollback claim if message wasn't sent


### PR DESCRIPTION
## What changed
- moved the `@everyone` mention out of the embed description and into the top-level Discord message content for Bunny webhook announcements
- aligned the Bunny webhook payload shape with the already-working manual video announcement route
- added `mention_everyone` response logging so we can verify whether Discord accepted the broadcast ping

## Why
Discord does not trigger real `@everyone` notifications from embed text. The automatic upload-complete webhook was posting the mention only inside the embed, so the announcement looked correct visually but did not actually ping members.

## Impact
Automatic Discord announcements posted after Bunny finishes processing a video should now trigger the expected `@everyone` ping.

## Validation
- ran `npx eslint app/api/webhooks/bunny/route.ts`
- compared the Bunny webhook payload structure with the existing working `/api/discord/video-announcement` route
