### PR TITLE
[codex] Fix mentorship Bunny thumbnail host mismatch

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ import { GoogleTagManager } from '@/components/analytics/google-tag-manager'
 import { MicrosoftClarity } from '@/components/analytics/microsoft-clarity'
 import { JsonLd } from '@/components/seo/json-ld'
 import { Suspense, lazy } from 'react'
+import { CURRENT_BUNNY_THUMBNAIL_HOST } from '@/lib/bunny-thumbnail'
 
 // Agentation nur in Development laden (ist devDependency)
 const Agentation = process.env.NODE_ENV === 'development' 
@@ -101,7 +102,7 @@ export default function RootLayout({
     <ClerkProvider afterSignOutUrl={"/"} localization={deDE} signInFallbackRedirectUrl="/dashboard" signUpFallbackRedirectUrl="/dashboard">
       <html lang="de" className="h-full scroll-smooth">
         <head>
-          <link rel="preconnect" href="https://vz-dc8da426-d71.b-cdn.net" crossOrigin="" />
+          <link rel="preconnect" href={`https://${CURRENT_BUNNY_THUMBNAIL_HOST}`} crossOrigin="" />
           <link rel="preconnect" href="https://iframe.mediadelivery.net" crossOrigin="" />
           <JsonLd />
         </head>

--- a/components/mentorship/video-thumbnail.tsx
+++ b/components/mentorship/video-thumbnail.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import Image from 'next/image'
 import { Check, FilmStrip as Film } from '@phosphor-icons/react'
+import { normalizeBunnyThumbnailUrl } from '@/lib/bunny-thumbnail'
 
 const THUMBNAIL_RETRY_DELAYS_MS = [5000, 15000, 30000, 60000] as const
 
@@ -58,12 +59,9 @@ export function VideoThumbnail({
     const appendCacheBust = (src: string) =>
       `${src}${src.includes('?') ? '&' : '?'}${cacheBust}`
 
-    if (thumbnailUrl) {
-      return appendCacheBust(thumbnailUrl)
-    }
-
-    if (bunnyGuid) {
-      return appendCacheBust(`https://vz-dc8da426-d71.b-cdn.net/${bunnyGuid}/thumbnail.jpg`)
+    const normalizedThumbnailUrl = normalizeBunnyThumbnailUrl(thumbnailUrl, bunnyGuid)
+    if (normalizedThumbnailUrl) {
+      return appendCacheBust(normalizedThumbnailUrl)
     }
 
     return null

--- a/lib/bunny-thumbnail.ts
+++ b/lib/bunny-thumbnail.ts
@@ -1,0 +1,33 @@
+export const CURRENT_BUNNY_THUMBNAIL_HOST = 'vz-08bb86cc-ee1.b-cdn.net'
+
+export function buildBunnyThumbnailUrl(videoGuid: string): string {
+  return `https://${CURRENT_BUNNY_THUMBNAIL_HOST}/${videoGuid}/thumbnail.jpg`
+}
+
+export function normalizeBunnyThumbnailUrl(
+  thumbnailUrl: string | null | undefined,
+  videoGuid: string | null | undefined
+): string | null {
+  if (thumbnailUrl) {
+    try {
+      const url = new URL(thumbnailUrl)
+      const expectedPath = videoGuid ? `/${videoGuid}/thumbnail.jpg` : null
+      const isBunnyThumbnail =
+        url.protocol === 'https:' &&
+        url.pathname.endsWith('/thumbnail.jpg') &&
+        (!expectedPath || url.pathname === expectedPath)
+
+      if (isBunnyThumbnail) {
+        url.hostname = CURRENT_BUNNY_THUMBNAIL_HOST
+        return url.toString()
+      }
+
+      return thumbnailUrl
+    } catch {
+      // Historisch defekte Thumbnail-Strings sollen auf den GUID-Fallback fallen.
+    }
+  }
+
+  if (!videoGuid) return null
+  return buildBunnyThumbnailUrl(videoGuid)
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,11 @@ const nextConfig = {
       },
       {
         protocol: 'https',
+        hostname: 'vz-08bb86cc-ee1.b-cdn.net',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
         hostname: 'vz-dc8da426-d71.b-cdn.net',
         pathname: '/**',
       },


### PR DESCRIPTION
## What changed
- normalized mentorship thumbnail URLs onto the current Bunny CDN host before rendering
- added a shared Bunny thumbnail helper for the UI host and URL construction
- updated the app preconnect and image config to include the active Bunny thumbnail host

## Why
The mentorship sidebar thumbnail component was still falling back to an older Bunny CDN hostname. When a video had no stored `thumbnailUrl`, or an older URL was still saved, the image request went to the wrong host and never resolved, so the UI stayed in the thumbnail loading/retry state.

## Impact
Mentorship thumbnails should now load from the same Bunny CDN host used elsewhere in the app, and older stored Bunny thumbnail URLs are rewritten on the fly to the active host.

## Validation
- sanity-checked the new helper by resolving fallback and normalized thumbnail URLs locally
- ran `npx eslint components/mentorship/video-thumbnail.tsx app/layout.tsx next.config.ts lib/bunny-thumbnail.ts`
- lint reports one existing warning in `components/mentorship/video-thumbnail.tsx` about `setState` inside an effect, but no new errors from this patch
