### PR TITLE
[codex] Refine PAT typography with Geist and mentorship heading overrides

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,16 +2,30 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: var(--font-geist-sans), system-ui, sans-serif;
+}
+
 /* Typography: Display font for headings with text-balance */
 @layer base {
   h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-sora), var(--font-inter), system-ui, sans-serif;
+    font-family: var(--font-sora), var(--font-geist-sans), system-ui, sans-serif;
     text-wrap: balance;
   }
   
   p {
     text-wrap: pretty;
   }
+}
+
+.mentorship-typography :is(h1, h2, h3, h4, h5, h6) {
+  font-family: var(--font-geist-sans), system-ui, sans-serif;
+  letter-spacing: -0.02em;
 }
 
 /* CSS Custom Properties für Glass Button */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next'
-import { Inter, Sora } from 'next/font/google'
+import localFont from 'next/font/local'
+import { Sora } from 'next/font/google'
 import './globals.css'
 import { Toaster } from '@/components/ui/toaster'
 import { Navbar } from '@/components/layout/navbar'
@@ -19,9 +20,16 @@ const Agentation = process.env.NODE_ENV === 'development'
   ? lazy(() => import('agentation').then(mod => ({ default: mod.Agentation })))
   : () => null
 
-const inter = Inter({ 
-  subsets: ['latin'],
-  variable: '--font-inter',
+const geistSans = localFont({
+  src: './fonts/GeistVF.woff',
+  variable: '--font-geist-sans',
+  display: 'swap',
+})
+
+const geistMono = localFont({
+  src: './fonts/GeistMonoVF.woff',
+  variable: '--font-geist-mono',
+  display: 'swap',
 })
 
 const sora = Sora({ 
@@ -105,7 +113,7 @@ export default function RootLayout({
           <link rel="preconnect" href="https://iframe.mediadelivery.net" crossOrigin="" />
           <JsonLd />
         </head>
-        <body className={`${inter.variable} ${sora.variable} font-sans h-full overflow-x-hidden`}>
+        <body className={`${geistSans.variable} ${geistMono.variable} ${sora.variable} font-sans antialiased h-full overflow-x-hidden`}>
           <a
             href="#main-content"
             className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-slate-900 focus:shadow-lg"

--- a/app/mentorship/layout.tsx
+++ b/app/mentorship/layout.tsx
@@ -25,5 +25,5 @@ export default async function CoursesLayout({ children }: { children: ReactNode 
   // Wichtig für UX: Mentorship ist "App-like" und braucht eine definierte Höhe,
   // damit interne ScrollAreas (MiddleSidebar) wirklich scrollen statt die Seite endlos zu verlängern.
   // 4rem = Navbar-Höhe (h-16).
-  return <div className="h-[calc(100dvh-4rem)] min-h-0">{children}</div>
+  return <div className="mentorship-typography h-[calc(100dvh-4rem)] min-h-0">{children}</div>
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,8 +23,9 @@ const config = {
   	},
   	extend: {
   		fontFamily: {
-  			sans: ['var(--font-inter)', 'system-ui', 'sans-serif'],
-  			display: ['var(--font-sora)', 'var(--font-inter)', 'system-ui', 'sans-serif'],
+  			sans: ['var(--font-geist-sans)', 'system-ui', 'sans-serif'],
+  			display: ['var(--font-sora)', 'var(--font-geist-sans)', 'system-ui', 'sans-serif'],
+  			mono: ['var(--font-geist-mono)', 'ui-monospace', 'monospace'],
   		},
   		keyframes: {
   			'toast-progress': {


### PR DESCRIPTION
## What changed
- switched the app’s base sans and mono typography to the local Geist variable fonts already present in the repo
- enabled font antialiasing and OS-level font smoothing for a cleaner overall text rendering
- kept the existing Sora display treatment for general site headings
- added a mentorship-only typography wrapper so headings inside `/mentorship` use Geist Sans in a TRU-style product UI treatment

## Why
The TRU ICT repo looks typographically cleaner mainly because it uses Geist Sans/Mono with antialiasing and font smoothing. For Price Action Trader, we wanted that cleaner text rendering globally without losing the more branded Sora-based display feel on the public-facing sections. The mentorship area is more app-like, so it now shifts its headings to the same Geist-based look used in TRU.

## Impact
- body copy and UI text across the app should render cleaner and more refined
- public/marketing sections keep their current display-character via Sora headings
- mentorship pages now feel more product-like and closer to TRU ICT typography

## Validation
- ran `npx eslint app/layout.tsx app/mentorship/layout.tsx tailwind.config.ts`
- `app/globals.css` is part of the patch but is not linted by the current ESLint configuration
