### PR TITLE
[codex] Finish mentorship title typography parity

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -23,7 +23,17 @@ body {
   }
 }
 
-.mentorship-typography :is(h1, h2, h3, h4, h5, h6) {
+.mentorship-typography :is(
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  [data-slot='dialog-title'],
+  [data-slot='alert-dialog-title'],
+  .mentorship-ui-heading
+) {
   font-family: var(--font-geist-sans), system-ui, sans-serif;
   letter-spacing: -0.02em;
 }

--- a/components/middle-sidebar.tsx
+++ b/components/middle-sidebar.tsx
@@ -829,7 +829,7 @@ export function MiddleSidebar({
             open={deleteDialogChapterId !== null}
             onOpenChange={() => setDeleteDialogChapterId(null)}
           >
-            <AlertDialogContent>
+            <AlertDialogContent className="mentorship-typography">
               <AlertDialogHeader>
                 <AlertDialogTitle>Kapitel löschen?</AlertDialogTitle>
                 <AlertDialogDescription>

--- a/components/module-card.tsx
+++ b/components/module-card.tsx
@@ -226,7 +226,7 @@ export function ModuleCard({ modul, progress = null }: Props) {
           {/* Modals außerhalb – safe */}
           {isAdmin && (
           <Dialog open={editOpen} onOpenChange={setEditOpen}>
-            <DialogContent>
+            <DialogContent className="mentorship-typography">
                 <DialogHeader>
                 <DialogTitle>Modul bearbeiten</DialogTitle>
                 <DialogDescription>Ändere Name & Beschreibung.</DialogDescription>
@@ -281,7 +281,7 @@ export function ModuleCard({ modul, progress = null }: Props) {
             )}
           {isAdmin && (
           <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-            <AlertDialogContent>
+            <AlertDialogContent className="mentorship-typography">
                 <AlertDialogHeader>
                 <AlertDialogTitle>Modul löschen?</AlertDialogTitle>
                 <AlertDialogDescription>

--- a/components/module-grid-admin.tsx
+++ b/components/module-grid-admin.tsx
@@ -213,7 +213,7 @@ export function ModuleGridAdmin({ modules, playlistId, playlistName, mobileCours
                 </Card>
               </DialogTrigger>
 
-              <DialogContent className="sm:max-w-lg">
+              <DialogContent className="mentorship-typography sm:max-w-lg">
                 <DialogHeader>
                   <DialogTitle>Neues Modul zu {playlistId || 'Playlist'}</DialogTitle>
                   <DialogDescription>
@@ -280,5 +280,4 @@ export function ModuleGridAdmin({ modules, playlistId, playlistName, mobileCours
     </DndContext>
   )
 }
-
 

--- a/components/sidebar-admin.tsx
+++ b/components/sidebar-admin.tsx
@@ -739,7 +739,7 @@ export function SidebarAdmin({
           setIsCourseModalOpen(true)
         }}
       >
-        <DialogContent className="sm:max-w-lg">
+        <DialogContent className="mentorship-typography sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>
               {courseModalMode === 'create' ? 'Neuen Kurs anlegen' : 'Kurs bearbeiten'}
@@ -894,7 +894,7 @@ export function SidebarAdmin({
         <Accordion type="single" collapsible defaultValue="mentorship">
           <AccordionItem value="mentorship">
             <AccordionTrigger className="text-gray-400 font-medium py-3 px-4 hover:text-black rounded-lg transition-colors [&&]:hover:no-underline justify-between">
-              <span>PAT Mentorship 2026</span>
+              <span className="mentorship-ui-heading">PAT Mentorship 2026</span>
 
               {/* Plus-Button – nur für Admin */}
               {isAdmin && (
@@ -959,7 +959,7 @@ export function SidebarAdmin({
                           {item.icon}
                         </div>
                         <div className="flex-1 min-w-0">
-                          <p className="font-medium text-sm truncate">{item.title}</p>
+                          <p className="mentorship-ui-heading font-medium text-sm truncate">{item.title}</p>
                           <p className="text-xs text-muted-foreground">{item.subtitle}</p>
                         </div>
                       </div>
@@ -1102,7 +1102,7 @@ export function SidebarAdmin({
           if (!open) setDeleteCourseId(null)
         }}
       >
-        <AlertDialogContent>
+        <AlertDialogContent className="mentorship-typography">
           <AlertDialogHeader>
             <AlertDialogTitle>Kurs löschen?</AlertDialogTitle>
             <AlertDialogDescription>
@@ -1133,7 +1133,7 @@ export function SidebarAdmin({
         open={deletingPageId !== null}
         onOpenChange={(open) => { if (!open) setDeletingPageId(null) }}
       >
-        <AlertDialogContent>
+        <AlertDialogContent className="mentorship-typography">
           <AlertDialogHeader>
             <AlertDialogTitle>Seite löschen?</AlertDialogTitle>
             <AlertDialogDescription>
@@ -1179,7 +1179,7 @@ export function SidebarAdmin({
 
       {/* Page Create/Edit Modal */}
       <Dialog open={isPageModalOpen} onOpenChange={(open) => { if (!open) closePageModal() }}>
-        <DialogContent className="sm:max-w-md">
+        <DialogContent className="mentorship-typography sm:max-w-md">
           <DialogHeader>
             <DialogTitle>{pageModalMode === 'create' ? 'Neue Seite erstellen' : 'Seite bearbeiten'}</DialogTitle>
             <DialogDescription>
@@ -1294,5 +1294,4 @@ export function SidebarAdmin({
     </div>
   )
 }
-
 

--- a/components/sidebar-user.tsx
+++ b/components/sidebar-user.tsx
@@ -179,7 +179,7 @@ export function SidebarUser({ kurse, pages = [], savedSidebarOrder, activeCourse
         <Accordion type="single" collapsible defaultValue="mentorship">
           <AccordionItem value="mentorship">
             <AccordionTrigger className="text-gray-400 font-medium py-3 px-4 hover:text-black rounded-lg transition-colors [&&]:hover:no-underline justify-between">
-              <span>PAT Mentorship 2026</span>
+              <span className="mentorship-ui-heading">PAT Mentorship 2026</span>
             </AccordionTrigger>
 
             <AccordionContent className="px-1">
@@ -205,7 +205,7 @@ export function SidebarUser({ kurse, pages = [], savedSidebarOrder, activeCourse
                         {item.icon}
                       </div>
                       <div className="flex-1 min-w-0">
-                        <p className="font-medium text-[13px] sm:text-sm truncate">{item.title}</p>
+                        <p className="mentorship-ui-heading font-medium text-[13px] sm:text-sm truncate">{item.title}</p>
                         <p className="text-[11px] sm:text-xs text-muted-foreground">{item.subtitle}</p>
                       </div>
                     </div>
@@ -343,5 +343,4 @@ export function SidebarUser({ kurse, pages = [], savedSidebarOrder, activeCourse
     </div>
   )
 }
-
 

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -79,6 +79,7 @@ const AlertDialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
     ref={ref}
+    data-slot="alert-dialog-title"
     className={cn("text-lg font-semibold", className)}
     {...props}
   />

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -87,6 +87,7 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
+    data-slot="dialog-title"
     className={cn(
       "text-lg font-semibold leading-none tracking-tight",
       className


### PR DESCRIPTION
## What changed
- extended the mentorship typography override so it also covers explicit UI title hooks, not just semantic `h1`-`h6`
- added lightweight `data-slot` hooks for dialog and alert-dialog titles so mentorship-specific font rules can target portaled title components reliably
- wrapped mentorship admin dialogs and destructive confirmation dialogs with the mentorship typography context
- applied the mentorship title treatment to the mentorship sidebar section label and navigation item titles

## Why
PR #125 correctly moved the main mentorship headings to Geist, but two gaps remained:
- some title-like UI text in the mentorship area is not rendered as semantic heading tags
- Radix dialog and alert-dialog content is portaled to `body`, so it sits outside the `.mentorship-typography` wrapper and kept the old heading font treatment

## Impact
- mentorship page headings, dialog titles, confirmation titles, and key sidebar titles now share the same TRU-style Geist treatment
- the typography change stays scoped to the mentorship experience instead of leaking into marketing pages

## Validation
- ran `npx eslint components/ui/dialog.tsx components/ui/alert-dialog.tsx components/sidebar-user.tsx components/sidebar-admin.tsx components/module-card.tsx components/module-grid-admin.tsx components/middle-sidebar.tsx`
- result: no errors; existing warnings remain in `components/middle-sidebar.tsx` and `components/sidebar-admin.tsx`
