### PR TITLE
Fix: separate RaidMapSubscription cache

### DIFF
--- a/lib/raidmap-access.ts
+++ b/lib/raidmap-access.ts
@@ -16,13 +16,6 @@ export type RaidMapAccessState = {
 
 const ACTIVE_STATUSES = new Set(['active', 'trialing', 'past_due'])
 
-function asPriceIdList(priceIds: unknown): string[] {
-  if (Array.isArray(priceIds)) {
-    return priceIds.filter((p): p is string => typeof p === 'string')
-  }
-  return []
-}
-
 export async function getRaidMapAccessState(userId: string): Promise<RaidMapAccessState> {
   // Dev-only Test-Mode: simulierter Abo-Zustand für den Test-User, keine DB-Abfrage
   // (doppelt geguarded in lib/raidmap-test-mode.ts, in Production immer aus).
@@ -31,7 +24,7 @@ export async function getRaidMapAccessState(userId: string): Promise<RaidMapAcce
   }
 
   const subscription = await withPrismaRetry(
-    () => prisma.userSubscription.findUnique({ where: { userId } }),
+    () => prisma.raidMapSubscription.findUnique({ where: { userId } }),
     { label: 'Load raidmap subscription' }
   )
 
@@ -39,16 +32,17 @@ export async function getRaidMapAccessState(userId: string): Promise<RaidMapAcce
     return { hasAccess: false, status: null, tier: null }
   }
 
-  const priceIds = asPriceIdList(subscription.priceIds)
   const monthlyId = getRaidMapPriceId('monthly')
   const annualId = getRaidMapPriceId('annual')
 
   const tier: RaidMapAccessState['tier'] =
-    annualId && priceIds.includes(annualId)
-      ? 'annual'
-      : monthlyId && priceIds.includes(monthlyId)
-        ? 'monthly'
-        : null
+    subscription.tier === 'annual' || subscription.tier === 'monthly'
+      ? subscription.tier
+      : subscription.priceId && subscription.priceId === annualId
+        ? 'annual'
+        : subscription.priceId && subscription.priceId === monthlyId
+          ? 'monthly'
+          : null
 
   const hasAccess = tier !== null && ACTIVE_STATUSES.has(subscription.status)
 

--- a/lib/stripe-webhook-handler.ts
+++ b/lib/stripe-webhook-handler.ts
@@ -114,6 +114,47 @@ async function upsertUserSubscription(params: {
   })
 }
 
+
+// Raid-Map-Abos: eigener Cache (RaidMapSubscription), komplett getrennt vom
+// Mentorship-Pfad. userId kommt aus subscription.metadata (wird im Checkout
+// immer gesetzt) — der Raid-Map-Customer traegt bewusst KEIN metadata.userId.
+async function upsertRaidMapSubscription(subscription: Stripe.Subscription) {
+  const userId = subscription.metadata?.userId
+  if (!userId) {
+    console.warn('[raidmap] subscription event ohne metadata.userId — skip', subscription.id)
+    return
+  }
+
+  const customerId =
+    typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id
+  const priceId = subscription.items?.data?.[0]?.price?.id ?? null
+
+  await prisma.raidMapSubscription.upsert({
+    where: { userId },
+    create: {
+      userId,
+      stripeCustomerId: customerId ?? '',
+      stripeSubscriptionId: subscription.id,
+      status: subscription.status,
+      tier: subscription.metadata?.tier ?? null,
+      priceId,
+      cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
+      currentPeriodEnd: unixToDate(subscription.current_period_end),
+    },
+    update: {
+      stripeCustomerId: customerId ?? '',
+      stripeSubscriptionId: subscription.id,
+      status: subscription.status,
+      tier: subscription.metadata?.tier ?? null,
+      priceId,
+      cancelAtPeriodEnd: Boolean(subscription.cancel_at_period_end),
+      currentPeriodEnd: unixToDate(subscription.current_period_end),
+    },
+  })
+
+  console.log('[raidmap] subscription cached', { userId, status: subscription.status })
+}
+
 async function getCustomerInfo(customerId: string): Promise<{
   email: string | null
   appUserId: string | null
@@ -217,6 +258,11 @@ export async function handleStripeEvent(event: Stripe.Event) {
 
       case 'customer.subscription.created': {
         const subscription = event.data.object as Stripe.Subscription
+        if (subscription.metadata?.product === 'raidmap') {
+          // Raid Map: eigener Cache, kein Mentorship-Discord/-Rollen-Pfad
+          await upsertRaidMapSubscription(subscription)
+          break
+        }
         const customerId = getCustomerIdFromSubscription(subscription)
 
         if (customerId) {
@@ -262,6 +308,11 @@ export async function handleStripeEvent(event: Stripe.Event) {
 
       case 'customer.subscription.updated': {
         const subscription = event.data.object as Stripe.Subscription
+        if (subscription.metadata?.product === 'raidmap') {
+          // Raid Map: eigener Cache, kein Mentorship-Discord/-Rollen-Pfad
+          await upsertRaidMapSubscription(subscription)
+          break
+        }
         const customerId = getCustomerIdFromSubscription(subscription)
 
         const prev = event.data.previous_attributes as
@@ -374,6 +425,11 @@ export async function handleStripeEvent(event: Stripe.Event) {
 
       case 'customer.subscription.deleted': {
         const subscription = event.data.object as Stripe.Subscription
+        if (subscription.metadata?.product === 'raidmap') {
+          // Raid Map: eigener Cache, kein Mentorship-Discord/-Rollen-Pfad
+          await upsertRaidMapSubscription(subscription)
+          break
+        }
         const customerId = getCustomerIdFromSubscription(subscription)
 
         if (customerId) {

--- a/prisma/migrations/20260707120000_add_raidmap_subscription/migration.sql
+++ b/prisma/migrations/20260707120000_add_raidmap_subscription/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "RaidMapSubscription" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "stripeCustomerId" TEXT NOT NULL,
+    "stripeSubscriptionId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "tier" TEXT,
+    "priceId" TEXT,
+    "cancelAtPeriodEnd" BOOLEAN NOT NULL DEFAULT false,
+    "currentPeriodEnd" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RaidMapSubscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RaidMapSubscription_userId_key" ON "RaidMapSubscription"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RaidMapSubscription_stripeSubscriptionId_key" ON "RaidMapSubscription"("stripeSubscriptionId");
+
+-- CreateIndex
+CREATE INDEX "RaidMapSubscription_status_idx" ON "RaidMapSubscription"("status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -235,6 +235,28 @@ model UserSubscription {
   @@index([stripeSubscriptionId])
 }
 
+// Raid-Map-Abos laufen ueber einen EIGENEN Stripe-Customer (USD) und werden
+// bewusst getrennt vom Mentorship-Cache (UserSubscription, 1 Zeile/User)
+// gehalten — sonst ueberschreiben sich die beiden Abos gegenseitig.
+model RaidMapSubscription {
+  id     String @id @default(uuid())
+  userId String @unique
+
+  stripeCustomerId     String
+  stripeSubscriptionId String @unique
+
+  status            String
+  tier              String?
+  priceId           String?
+  cancelAtPeriodEnd Boolean   @default(false)
+  currentPeriodEnd  DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([status])
+}
+
 model LeadMagnetSubscriber {
   id          String   @id @default(uuid())
   email       String   @unique


### PR DESCRIPTION
UserSubscription is one row per user; a raid-map purchase overwrote the mentorship cache (and vice versa). Raid-map subs now live in their own table; webhook path fully separated; access check reads the new table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)