### PR TITLE
fix: grant Raid Map access instantly

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,8 +5,7 @@ import './globals.css'
 import { ToasterLoader } from '@/components/ui/toaster-loader'
 import { Navbar } from '@/components/layout/navbar'
 import { Footer } from '@/components/layout/footer'
-import {ClerkProvider} from '@clerk/nextjs'
-import { deDE } from '@clerk/localizations'
+import { LocalizedClerkProvider } from '@/components/layout/localized-clerk-provider'
 import { CookieBannerLoader } from '@/components/ui/cookie-banner-loader'
 import { AnalyticsScriptsLoader } from '@/components/analytics/analytics-scripts-loader'
 import { JsonLd } from '@/components/seo/json-ld'
@@ -104,7 +103,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <ClerkProvider afterSignOutUrl={"/"} localization={deDE} signInFallbackRedirectUrl="/dashboard" signUpFallbackRedirectUrl="/dashboard">
+    <LocalizedClerkProvider>
       <html lang="de" className="h-full scroll-smooth">
         <head>
           <link rel="preconnect" href={`https://${CURRENT_BUNNY_THUMBNAIL_HOST}`} crossOrigin="" />
@@ -137,6 +136,6 @@ export default function RootLayout({
           )}
         </body>
       </html>
-    </ClerkProvider>
+    </LocalizedClerkProvider>
   )
 }

--- a/app/raid-map/account/actions.ts
+++ b/app/raid-map/account/actions.ts
@@ -2,7 +2,10 @@
 
 import { auth } from '@clerk/nextjs/server'
 import { revalidatePath } from 'next/cache'
-import { claimIndicatorForUser } from '@/lib/indicators/store'
+import {
+  claimIndicatorForUser,
+  processTradingViewClaimInstantly,
+} from '@/lib/indicators/store'
 import { prisma, withPrismaRetry } from '@/lib/prisma'
 import { getRaidMapAccessState, getRaidMapIndicator } from '@/lib/raidmap-access'
 import { RAIDMAP_CONFIG } from '@/lib/raidmap-config'
@@ -43,6 +46,31 @@ export async function claimRaidMapAction(tvUsername: string): Promise<RaidMapCla
     allowRebind: true,
   })
 
+  let message = result.message ?? (result.ok ? 'Access request queued.' : 'Something went wrong.')
+  if (result.ok && result.claimStatus !== 'granted') {
+    try {
+      const instant = await processTradingViewClaimInstantly({
+        userId,
+        indicatorId: indicator.id,
+        workerId: 'raidmap-account-instant',
+      })
+
+      if (instant.status === 'granted') {
+        message = 'Access granted — PAT Raid Map is now available on your TradingView account.'
+      } else if (instant.blockedBySession) {
+        message = 'Your request is saved. We are reconnecting TradingView and will retry automatically.'
+      } else if (instant.status === 'processing') {
+        message = 'Your request is saved and is being processed right now.'
+      } else if (instant.status === 'failed') {
+        message =
+          instant.errorMessage ??
+          'TradingView could not finish the activation yet. We will retry automatically.'
+      }
+    } catch (error) {
+      console.error('[raidmap] Instant account claim failed; cron will retry:', error)
+    }
+  }
+
   if (result.ok && result.reboundFrom) {
     const revoke = result.rebindRevoke
     if (revoke && revoke.failed > 0) {
@@ -63,7 +91,7 @@ export async function claimRaidMapAction(tvUsername: string): Promise<RaidMapCla
   }
 
   revalidatePath(RAIDMAP_CONFIG.accountPath)
-  return { ok: result.ok, message: result.message ?? (result.ok ? 'Access request queued.' : 'Something went wrong.') }
+  return { ok: result.ok, message }
 }
 
 export type RaidMapTestimonialResult = { ok: boolean; message: string }

--- a/components/layout/localized-clerk-provider.tsx
+++ b/components/layout/localized-clerk-provider.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { ClerkProvider } from '@clerk/nextjs'
+import { deDE, enUS } from '@clerk/localizations'
+import { usePathname } from 'next/navigation'
+
+function usesEnglishAccountUi(pathname: string) {
+  if (!pathname.startsWith('/raid-map')) return false
+  const isGermanRoute =
+    pathname === '/raid-map/de' ||
+    pathname.startsWith('/raid-map/de/') ||
+    pathname === '/raid-map/docs/de' ||
+    pathname.startsWith('/raid-map/docs/de/')
+
+  return !isGermanRoute
+}
+
+export function LocalizedClerkProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+  const localization = usesEnglishAccountUi(pathname) ? enUS : deDE
+
+  return (
+    <ClerkProvider
+      afterSignOutUrl="/"
+      localization={localization}
+      signInFallbackRedirectUrl="/dashboard"
+      signUpFallbackRedirectUrl="/dashboard"
+    >
+      {children}
+    </ClerkProvider>
+  )
+}

--- a/lib/indicators/store.ts
+++ b/lib/indicators/store.ts
@@ -1317,9 +1317,11 @@ async function markDueClaimsAsNeedsSession(message: string, code: string) {
 export async function processTradingViewClaimQueue({
   limit = 25,
   workerId = 'admin-manual',
+  claimId,
 }: {
   limit?: number
   workerId?: string
+  claimId?: string
 } = {}): Promise<AdminIndicatorClaimRetrySummary> {
   const tv = new TradingViewService(await getTvSessionSecret())
   const cappedLimit = Math.max(1, Math.min(limit, 100))
@@ -1373,6 +1375,7 @@ export async function processTradingViewClaimQueue({
 
   const rows = await prisma.indicatorClaim.findMany({
     where: {
+      ...(claimId ? { id: claimId } : {}),
       status: { in: ['pending', 'failed', 'needs_session'] },
       OR: [{ nextRetryAt: null }, { nextRetryAt: { lte: new Date() } }],
     },
@@ -1505,6 +1508,42 @@ export async function processTradingViewClaimQueue({
       attempted === 0
         ? 'Keine TradingView-Claims sind gerade bereit.'
         : `${attempted} TradingView-Claims verarbeitet: ${granted} granted, ${failed} failed, ${skipped} skipped.`,
+  }
+}
+
+export async function processTradingViewClaimInstantly(input: {
+  userId: string
+  indicatorId: string
+  workerId: string
+}) {
+  const where = {
+    userId_indicatorId: {
+      userId: input.userId,
+      indicatorId: input.indicatorId,
+    },
+  }
+  const select = { id: true, status: true, errorMessage: true } as const
+  const existingClaim = await prisma.indicatorClaim.findUnique({ where, select })
+
+  if (!existingClaim || existingClaim.status === 'granted' || existingClaim.status === 'processing') {
+    return {
+      status: existingClaim ? asClaimStatus(existingClaim.status) : null,
+      errorMessage: existingClaim?.errorMessage ?? null,
+      blockedBySession: false,
+    }
+  }
+
+  const workerResult = await processTradingViewClaimQueue({
+    limit: 1,
+    workerId: input.workerId,
+    claimId: existingClaim.id,
+  })
+  const updatedClaim = await prisma.indicatorClaim.findUnique({ where, select })
+
+  return {
+    status: updatedClaim ? asClaimStatus(updatedClaim.status) : null,
+    errorMessage: updatedClaim?.errorMessage ?? null,
+    blockedBySession: workerResult.blockedBySession,
   }
 }
 

--- a/lib/raidmap-fulfillment.ts
+++ b/lib/raidmap-fulfillment.ts
@@ -1,13 +1,16 @@
 import 'server-only'
 
 import type Stripe from 'stripe'
-import { claimIndicatorForUser } from '@/lib/indicators/store'
+import {
+  claimIndicatorForUser,
+  processTradingViewClaimInstantly,
+} from '@/lib/indicators/store'
 import { getRaidMapIndicator } from '@/lib/raidmap-access'
 import { sendCortanaTelegram } from '@/lib/telegram-notify'
 
 // Nach erfolgreichem Raid-Map-Checkout: TradingView-Username aus dem Checkout-
-// Custom-Field lesen und den Invite-Only-Claim in die bestehende Queue legen
-// (der stündliche TradingView-Cron erledigt den Grant über die Session-Cookies).
+// Custom-Field lesen und den Invite-Only-Claim sofort verarbeiten. Der
+// stündliche TradingView-Cron bleibt als Fallback für temporäre Fehler aktiv.
 // Fehler werden NUR geloggt — der Webhook darf am Fulfillment nie scheitern,
 // der Kunde kann den Username jederzeit im Account-Bereich nachtragen.
 
@@ -49,12 +52,20 @@ export async function handleRaidMapCheckoutCompleted(session: Stripe.Checkout.Se
       indicatorId: indicator.id,
       tvUsername,
     })
+    const instantResult =
+      result.ok && result.claimStatus !== 'granted'
+        ? await processTradingViewClaimInstantly({
+            userId,
+            indicatorId: indicator.id,
+            workerId: 'raidmap-checkout-instant',
+          })
+        : null
 
-    console.log('[raidmap] Checkout-Claim angelegt', {
+    console.log('[raidmap] Checkout-Claim verarbeitet', {
       userId,
       tvUsername,
       ok: result.ok,
-      claimStatus: 'claimStatus' in result ? result.claimStatus : undefined,
+      claimStatus: instantResult?.status ?? result.claimStatus,
       message: result.message,
     })
   } catch (error) {


### PR DESCRIPTION
## Summary

- process the exact PAT Raid Map claim immediately after checkout
- process account-page claims and username updates immediately
- keep the hourly TradingView cron as a fallback for temporary session or API failures
- show Clerk account/settings UI in English on English Raid Map routes while keeping German routes and the mentorship UI in German

## Root cause

The Raid Map account flow only persisted a pending claim. It did not trigger the instant worker used by the mentorship claim flow, so customers waited for the next hourly cron run. Clerk was also configured globally with `deDE`, which made account/settings dialogs German on the English product routes.

## User impact

When the saved TradingView session is healthy, new Raid Map claims are now targeted and granted immediately. Temporary TradingView failures remain durable because the hourly cron still retries them.

## Validation

- `npm run build`
- targeted ESLint check for all changed files
- Vercel Preview reached `READY`
- English and German Raid Map routes returned HTTP 200
- compiled Preview bundle contains the expected EN/DE route switch
- no Preview `error` or `fatal` runtime logs in the checked window

Preview: https://pat-mentorship-25-webpage-git-fix-raid-024150-petar23s-projects.vercel.app/raid-map

The visual Clerk modal click-through could not be completed because the connected Chrome extension stopped responding; the route logic itself was verified in the compiled Preview bundle.
