### PR TITLE
perf: improve UX and frontend performance

### DIFF
--- a/app/(dashboard)/dashboard/dashboard-conversion-client.tsx
+++ b/app/(dashboard)/dashboard/dashboard-conversion-client.tsx
@@ -10,6 +10,7 @@ import { CheckCircle as CircleCheckBig } from '@phosphor-icons/react/CheckCircle
 import { LockIcon } from '@phosphor-icons/react/Lock'
 import { Ticket } from '@phosphor-icons/react/Ticket'
 import { trackConversion } from '@/components/analytics/tracking'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 
 const CheckoutButton = dynamic(
   () => import('@/components/ui/checkout-button').then((mod) => mod.CheckoutButton),
@@ -93,9 +94,13 @@ export default function DashboardConversionClient({
                     <CalendarCheck className="h-5 w-5" />
                   </div>
                   <div>
-                    <p className="font-semibold text-blue-900">Mentorship startet bald</p>
+                    <p className="font-semibold text-blue-900">
+                      {MENTORSHIP_IS_UPCOMING ? 'Mentorship startet bald' : 'Mentorship-Zugang wird vorbereitet'}
+                    </p>
                     <p className="text-sm text-blue-900/80 mt-1">
-                      Du hast bereits ein aktives Abo! Der Mentorship-Bereich öffnet am 01.03.2026.
+                      {MENTORSHIP_IS_UPCOMING
+                        ? `Du hast bereits ein aktives Abo! Der Mentorship-Bereich öffnet am ${MENTORSHIP_CONFIG.startDateFormatted}.`
+                        : 'Du hast bereits ein aktives Abo. Lade die Seite neu, falls der Mentorship-Bereich noch nicht freigeschaltet ist.'}
                     </p>
                   </div>
                 </div>
@@ -143,7 +148,9 @@ export default function DashboardConversionClient({
                 inkl. gesetzl. MwSt. · monatlich kündbar
               </p>
               <p className="text-sm text-green-600 mt-1 font-medium">
-                Keine Zahlung bis 01. März 2026
+                {MENTORSHIP_IS_UPCOMING
+                  ? `Keine Zahlung bis ${MENTORSHIP_CONFIG.startDateFormatted}`
+                  : MENTORSHIP_CONFIG.paymentNote}
               </p>
             </div>
 

--- a/app/(dashboard)/dashboard/dashboard-member-client.tsx
+++ b/app/(dashboard)/dashboard/dashboard-member-client.tsx
@@ -9,6 +9,18 @@ import { BookOpen } from '@phosphor-icons/react/BookOpen'
 import { CreditCard } from '@phosphor-icons/react/CreditCard'
 import { LockIcon } from '@phosphor-icons/react/Lock'
 import { trackConversion } from '@/components/analytics/tracking'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
+
+function formatMentorshipDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return MENTORSHIP_CONFIG.startDateFormatted
+
+  return new Intl.DateTimeFormat('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).format(date)
+}
 
 const ManageSubscriptionButton = dynamic(
   () => import('@/components/ui/manage-subscription').then((mod) => mod.ManageSubscriptionButton),
@@ -73,9 +85,16 @@ export default function DashboardMemberClient({
   viewFlags,
 }: DashboardMemberClientProps) {
   const { showCheckoutSuccess, showCoursesPaywall } = viewFlags
+  const mentorshipStatus = initialData.mentorshipStatus
+  const mentorshipStartDate = formatMentorshipDate(initialData.mentorshipStatus.startDate)
+  const subscriptionStartDate = formatMentorshipDate(initialData.subscriptionDetails.startDate)
+  const subscriptionIsPending =
+    initialData.subscriptionDetails.isPending ||
+    initialData.subscriptionDetails.status === 'incomplete'
+  const hasMentorshipAccess =
+    initialData.hasSubscription && mentorshipStatus?.accessible
   const [showSuccessModal, setShowSuccessModal] = useState(() => showCheckoutSuccess)
   const hasTrackedPurchase = useRef(false)
-  const mentorshipStatus = initialData.mentorshipStatus
 
   useEffect(() => {
     if (showCheckoutSuccess && !hasTrackedPurchase.current) {
@@ -164,13 +183,19 @@ export default function DashboardMemberClient({
                 Hier kommst du direkt zur Discord-Verknüpfung und zum Mentorship-Bereich.
               </p>
 
-              {!mentorshipStatus?.accessible ? (
+              {!hasMentorshipAccess ? (
                 <Button
                   disabled
                   className="w-full bg-blue-600 hover:bg-blue-600 opacity-60 cursor-not-allowed"
-                  title="Mentorship startet am 01.03.2026"
+                  title={
+                    !initialData.hasSubscription
+                      ? 'Ein aktives Abonnement ist erforderlich.'
+                      : `Mentorship startet am ${mentorshipStartDate}`
+                  }
                 >
-                  Zur Mentorship Platform (Startet am 01.03.2026)
+                  {initialData.hasSubscription
+                    ? `Zur Mentorship Platform (Startet am ${mentorshipStartDate})`
+                    : 'Mentorship-Zugang nicht aktiv'}
                 </Button>
               ) : (
                 <Button asChild className="w-full bg-blue-600 hover:bg-blue-700">
@@ -192,11 +217,23 @@ export default function DashboardMemberClient({
               <div className="text-sm text-gray-600">
                 {initialData.subscriptionDetails.isCanceled ? (
                   <p className="text-red-600">
-                    Dein Abonnement wurde gekündigt. Erneuere jetzt dein Abonnement, um deinen Platz für das Programm ab 01. März 2026 zu sichern.
+                    Dein Abonnement wurde gekündigt. Erneuere es, um deinen Zugang zur Mentorship zu sichern.
+                  </p>
+                ) : subscriptionIsPending ? (
+                  <p className="text-amber-700">
+                    Dein Abonnement wird noch verarbeitet. Sobald die Zahlung bestätigt ist, wird dein Zugang automatisch freigeschaltet.
+                  </p>
+                ) : !initialData.hasSubscription ? (
+                  <p className="text-amber-700">
+                    Dein Abonnement ist aktuell nicht aktiv (Status: {initialData.subscriptionDetails.status}). Prüfe deine Zahlung oder reaktiviere das Abo im Kundenportal.
                   </p>
                 ) : (
                   <>
-                    <p>Dein Abonnement startet am 01. März 2026. Die erste Zahlung erfolgt automatisch an diesem Datum.</p>
+                    <p>
+                      {MENTORSHIP_IS_UPCOMING
+                        ? `Dein Abonnement startet am ${subscriptionStartDate}. Die erste Zahlung erfolgt automatisch an diesem Datum.`
+                        : 'Dein Abonnement ist aktiv und dein Mentorship-Zugang kann direkt genutzt werden.'}
+                    </p>
                     <p>Du kannst deine Zahlungsmethode und Abonnement-Einstellungen unten verwalten.</p>
                   </>
                 )}

--- a/app/api/pages/[id]/route.ts
+++ b/app/api/pages/[id]/route.ts
@@ -75,9 +75,18 @@ export async function PATCH(
   const updateData: Record<string, any> = {}
 
   if (body.title !== undefined) {
+    if (typeof body.title !== 'string') {
+      return NextResponse.json({ error: 'Ungültiger Seitentitel.' }, { status: 400 })
+    }
     const title = body.title.trim()
-    updateData.title = title
     const newSlug = generateSlug(title)
+    if (!title || !newSlug) {
+      return NextResponse.json(
+        { error: 'Der Seitentitel muss mindestens ein Zeichen oder eine Zahl enthalten.' },
+        { status: 400 }
+      )
+    }
+    updateData.title = title
     if (newSlug !== existing.slug) {
       const conflict = await prisma.page.findFirst({
         where: { slug: newSlug, NOT: { id } },

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -118,9 +118,7 @@ export default function RootLayout({
             Zum Inhalt springen
           </a>
           <div className="min-h-full flex flex-col">
-            <Suspense fallback={<div className="h-16 w-full" />}>
-              <Navbar />
-            </Suspense>
+            <Navbar />
             <main id="main-content" className="flex-1 min-h-0">
               {children}
             </main>

--- a/app/mentorship/indicators/actions.ts
+++ b/app/mentorship/indicators/actions.ts
@@ -3,13 +3,13 @@
 import { auth } from '@clerk/nextjs/server'
 import { revalidatePath } from 'next/cache'
 import { getIsAdmin } from '@/lib/authz'
-import { prisma } from '@/lib/prisma'
 import {
   claimIndicatorForUser,
   clearTradingViewCookie,
   createIndicator,
   createIndicatorPackage,
   importTradingViewIndicators,
+  processTradingViewClaimInstantly,
   processTradingViewClaimQueue,
   resetTradingViewAccountBinding,
   saveTradingViewCookie,
@@ -57,29 +57,20 @@ async function processClaimInstantly(input: {
   fallbackMessage: string
 }) {
   try {
-    const workerResult = await processTradingViewClaimQueue({
-      limit: 5,
+    const claim = await processTradingViewClaimInstantly({
+      userId: input.userId,
+      indicatorId: input.indicatorId,
       workerId: 'member-claim-instant',
     })
 
-    const claim = await prisma.indicatorClaim.findUnique({
-      where: {
-        userId_indicatorId: {
-          userId: input.userId,
-          indicatorId: input.indicatorId,
-        },
-      },
-      select: { status: true, errorMessage: true },
-    })
-
-    if (claim?.status === 'granted') {
+    if (claim.status === 'granted') {
       return {
         ok: true,
         message: 'Deine TradingView-Freigabe wurde direkt aktiviert.',
       }
     }
 
-    if (workerResult.blockedBySession) {
+    if (claim.blockedBySession) {
       return {
         ok: true,
         message:
@@ -87,14 +78,14 @@ async function processClaimInstantly(input: {
       }
     }
 
-    if (claim?.status === 'processing') {
+    if (claim.status === 'processing') {
       return {
         ok: true,
         message: 'Deine Anfrage ist gespeichert. Die TradingView-Freigabe wird gerade verarbeitet.',
       }
     }
 
-    if (claim?.status === 'failed') {
+    if (claim.status === 'failed') {
       return {
         ok: true,
         message:
@@ -105,7 +96,7 @@ async function processClaimInstantly(input: {
 
     return {
       ok: true,
-      message: claim?.errorMessage ?? input.fallbackMessage,
+      message: claim.errorMessage ?? input.fallbackMessage,
     }
   } catch (error) {
     console.error('[tradingview-claims] Instant processing failed:', error)

--- a/components/dashboard/countdown-progress.tsx
+++ b/components/dashboard/countdown-progress.tsx
@@ -17,6 +17,18 @@ export function CountdownProgress({ startDate }: CountdownProgressProps) {
       const now = new Date().getTime()
       const start = new Date('2024-11-04').getTime() // Current date
       const end = new Date(startDate).getTime()
+      if (!Number.isFinite(end)) {
+        setProgress(0)
+        setTimeLeft('Startdatum nicht verfügbar')
+        return true
+      }
+
+      if (end <= now) {
+        setProgress(100)
+        setTimeLeft('Die Mentorship ist gestartet.')
+        return true
+      }
+
       const total = end - start
       const elapsed = now - start
       const percentage = (elapsed / total) * 100
@@ -25,9 +37,10 @@ export function CountdownProgress({ startDate }: CountdownProgressProps) {
       // Calculate time left
       const days = Math.ceil((end - now) / (1000 * 60 * 60 * 24))
       setTimeLeft(`Noch ${days} Tage`)
+      return false
     }
 
-    calculateProgress()
+    if (calculateProgress()) return
     const interval = setInterval(calculateProgress, 1000 * 60 * 60) // Update every hour
     return () => clearInterval(interval)
   }, [startDate])

--- a/components/dashboard/subscription-status.tsx
+++ b/components/dashboard/subscription-status.tsx
@@ -11,6 +11,7 @@ import { Warning as AlertTriangle } from '@phosphor-icons/react/Warning'
 import { XCircle } from '@phosphor-icons/react/XCircle'
 import { Button } from '@/components/ui/button'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
+import { MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 import { CountdownProgress } from './countdown-progress'
 
 interface SubscriptionStatusProps {
@@ -110,10 +111,14 @@ export function SubscriptionStatus({
     if (status === 'active' || status === 'trialing') {
       return {
         icon: <Armchair className="h-5 w-5 text-emerald-500" />,
-        text: '🎉 Platz Gesichert!',
-        description: 'Dein Platz in der Mentorship wird freigehalten.',
-        subDescription: `Die Mentorship startet am ${formattedDate}`,
-        showCountdown: true,
+        text: MENTORSHIP_IS_UPCOMING ? '🎉 Platz gesichert!' : '🎉 Mitgliedschaft aktiv',
+        description: MENTORSHIP_IS_UPCOMING
+          ? 'Dein Platz in der Mentorship wird freigehalten.'
+          : 'Dein Zugang zur laufenden Mentorship ist freigeschaltet.',
+        subDescription: MENTORSHIP_IS_UPCOMING
+          ? `Die Mentorship startet am ${formattedDate}`
+          : 'Du kannst direkt mit den Inhalten und Aufzeichnungen starten.',
+        showCountdown: MENTORSHIP_IS_UPCOMING,
         showAlert: false,
         variant: 'success'
       }

--- a/components/dashboard/subscription-success-modal.tsx
+++ b/components/dashboard/subscription-success-modal.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { CheckCircle } from '@phosphor-icons/react/CheckCircle'
-import { MENTORSHIP_CONFIG } from '@/lib/config'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 import confetti from 'canvas-confetti'
 
 interface SuccessModalProps {
@@ -70,7 +70,9 @@ export function SubscriptionSuccessModal({ isOpen, onClose }: SuccessModalProps)
         </DialogHeader>
         <div className="text-center space-y-4">
           <p className="text-gray-600">
-            Dein Platz ist gesichert. Die Mentorship startet am {MENTORSHIP_CONFIG.startDateFormatted}
+            {MENTORSHIP_IS_UPCOMING
+              ? `Dein Platz ist gesichert. Die Mentorship startet am ${MENTORSHIP_CONFIG.startDateFormatted}.`
+              : 'Dein Platz ist gesichert. Du kannst jetzt direkt mit der Mentorship starten.'}
           </p>
           <Button onClick={onClose} className="w-full">
             Zum Dashboard

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -3,7 +3,7 @@
 import { useUser } from '@clerk/nextjs'
 import { UserButton, SignInButton } from '@clerk/nextjs'
 import Link from 'next/link'
-import { usePathname, useSearchParams } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import Image from 'next/image'
 import { Button } from '@/components/ui/button'
 import { Gauge } from '@phosphor-icons/react/Gauge'
@@ -30,6 +30,19 @@ type IdleWindow = Window & {
 
 function getMentorshipStatusCacheKey(userId: string) {
   return `mentorship-nav-status:${userId}`
+}
+
+function formatMentorshipStartDate(value?: string) {
+  if (!value) return MENTORSHIP_CONFIG.startDateFormatted
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return MENTORSHIP_CONFIG.startDateFormatted
+
+  return new Intl.DateTimeFormat('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).format(date)
 }
 
 function readCachedMentorshipStatus(userId: string): MentorshipStatus | null {
@@ -73,7 +86,6 @@ export function Navbar() {
   const [isOpen, setIsOpen] = useState(false)
   const [mentorshipStatus, setMentorshipStatus] = useState<MentorshipStatus | null>(null)
   const pathname = usePathname()
-  const searchParams = useSearchParams()
   const postCheckoutRef = useRef(false)
 
   const isMentorship = pathname?.startsWith('/mentorship')
@@ -82,7 +94,7 @@ export function Navbar() {
     membership => membership.role === 'org:admin'
   )
   const userId = user?.id ?? null
-  const isCheckoutSuccess = isDashboard && searchParams.get('success') === 'true'
+  const mentorshipStartLabel = formatMentorshipStartDate(mentorshipStatus?.startDate)
 
   // Lade Mentorship-Status beim ersten Laden
   useEffect(() => {
@@ -94,6 +106,8 @@ export function Navbar() {
 
     // Wenn wir aus Stripe zurückkommen, kann es ein paar Sekunden dauern bis Webhooks/DB aktuell sind.
     // Deshalb pollen wir kurz, damit der Mentorship-Button ohne Refresh sofort erscheint.
+    const isCheckoutSuccess =
+      isDashboard && new URLSearchParams(window.location.search).get('success') === 'true'
     if (isCheckoutSuccess) {
       postCheckoutRef.current = true
     }
@@ -193,7 +207,7 @@ export function Navbar() {
       }
       if (fallbackIdleId) clearTimeout(fallbackIdleId)
     }
-  }, [isAdmin, isSignedIn, isCheckoutSuccess, isMentorship, userId])
+  }, [isAdmin, isDashboard, isSignedIn, isMentorship, userId])
 
   // Prevent body scroll when menu is open
   useEffect(() => {
@@ -245,12 +259,12 @@ export function Navbar() {
                             variant="outline"
                             className="flex items-center gap-3 bg-gray-900 hover:bg-gray-800 text-gray-300 border-gray-700 cursor-not-allowed px-3 py-1 leading-tight"
                             disabled
-                            title={`Mentorship startet ab ${MENTORSHIP_CONFIG.startDateFormatted}`}
+                            title={`Mentorship startet ab ${mentorshipStartLabel}`}
                           >
                             <Notebook className="h-5 w-5" />
                             <div className="flex flex-col items-start gap-0">
                               <span className="text-sm">Mentorship</span>
-                              <span className="text-[10px] text-gray-400 mb-1">Start {MENTORSHIP_CONFIG.startDateFormatted}</span>
+                              <span className="text-[10px] text-gray-400 mb-1">Start {mentorshipStartLabel}</span>
                             </div>
                           </Button>
                         ) : (
@@ -367,12 +381,12 @@ export function Navbar() {
                             variant="outline"
                             className="w-full flex items-center gap-3 bg-gray-900 hover:bg-gray-800 text-gray-300 border-gray-700 cursor-not-allowed px-3 py-1 leading-tight"
                             disabled
-                            title={`Mentorship startet ab ${MENTORSHIP_CONFIG.startDateFormatted}`}
+                            title={`Mentorship startet ab ${mentorshipStartLabel}`}
                           >
                             <Notebook className="h-5 w-5" />
                             <div className="flex flex-col items-start gap-0">
                               <span className="text-sm">Mentorship</span>
-                              <span className="text-[10px] text-gray-400 mb-1">Start {MENTORSHIP_CONFIG.startDateFormatted}</span>
+                              <span className="text-[10px] text-gray-400 mb-1">Start {mentorshipStartLabel}</span>
                             </div>
                           </Button>
                         ) : (

--- a/components/middle-sidebar-user.tsx
+++ b/components/middle-sidebar-user.tsx
@@ -81,23 +81,27 @@ function VideoRow({
   onClick,
   durationText,
   isWatched,
+  tabIndex,
 }: {
   video: Video
   isActive: boolean
   onClick: () => void
   durationText: string
   isWatched: boolean
+  tabIndex?: number
 }) {
   return (
-    <div
+    <button
+      type="button"
       className={[
-        'p-2 flex items-center space-x-2 cursor-pointer transition-colors rounded-md border border-l-4',
+        'w-full p-2 flex items-center space-x-2 cursor-pointer text-left transition-colors rounded-md border border-l-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         isActive
           ? 'bg-gray-100 dark:bg-gray-800/60 border-gray-200 dark:border-gray-700 border-l-gray-400 dark:border-l-gray-400'
           : 'border-transparent border-l-transparent hover:bg-gray-100 dark:hover:bg-gray-800/40',
       ].join(' ')}
       onClick={onClick}
       aria-current={isActive ? 'true' : undefined}
+      tabIndex={tabIndex}
     >
       <VideoThumbnail
         bunnyGuid={video.bunnyGuid}
@@ -113,7 +117,7 @@ function VideoRow({
         </p>
         <p className="text-xs text-muted-foreground">{durationText}</p>
       </div>
-    </div>
+    </button>
   )
 }
 
@@ -219,25 +223,30 @@ export function MiddleSidebarUser({
           {sortedChapters.map((chapter) => {
             const isOpen = openChapters.has(chapter.id)
             const sortedVideos = [...chapter.videos].sort((a, b) => (a.order || 0) - (b.order || 0))
+            const chapterContentId = `chapter-videos-${chapter.id}`
 
             return (
               <Card className="border border-border shadow-sm" key={chapter.id}>
                 <CardContent className="p-2">
                   <div className="flex items-center justify-between select-none">
                     <div className="flex items-center space-x-3 flex-1">
-                      <span
-                        className="cursor-pointer p-1 hover:bg-accent/50 rounded flex-shrink-0"
+                      <button
+                        type="button"
+                        className="h-8 w-8 cursor-pointer rounded flex flex-shrink-0 items-center justify-center hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                         onClick={(e) => {
                           e.stopPropagation()
                           toggleChapter(chapter.id)
                         }}
+                        aria-expanded={isOpen}
+                        aria-controls={chapterContentId}
+                        aria-label={`${chapter.name} ${isOpen ? 'einklappen' : 'ausklappen'}`}
                       >
                         {isOpen ? (
                           <ChevronDown className="h-4 w-4 text-muted-foreground" />
                         ) : (
                           <ChevronRight className="h-4 w-4 text-muted-foreground" />
                         )}
-                      </span>
+                      </button>
 
                       <h3 className="text-md font-bold truncate flex-1 px-2 py-1 rounded select-text">
                         {chapter.name}
@@ -246,6 +255,8 @@ export function MiddleSidebarUser({
                   </div>
 
                   <div
+                    id={chapterContentId}
+                    aria-hidden={!isOpen}
                     className={`grid transition-all duration-300 ease-in-out ${
                       isOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
                     }`}
@@ -265,6 +276,7 @@ export function MiddleSidebarUser({
                                 onClick={() => onVideoClick(video.id)}
                                 durationText={getDurationText(video)}
                                 isWatched={isWatched}
+                                tabIndex={isOpen ? 0 : -1}
                               />
                             )
                           })

--- a/components/page-editor.tsx
+++ b/components/page-editor.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback, useState } from 'react'
 import { useEditor, EditorContent, type Editor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import { Image as ImageExtension } from '@tiptap/extension-image'
@@ -54,6 +54,19 @@ type Props = {
   page: PageData
 }
 
+type SaveRequest = {
+  content: Record<string, unknown>
+  title?: string
+  revision: number
+  keepalive?: boolean
+}
+
+type SaveResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+type SaveStatus = 'idle' | 'saving' | 'saved' | 'error'
+
 function ToolbarButton({
   onClick,
   active,
@@ -73,8 +86,9 @@ function ToolbarButton({
       onClick={onClick}
       disabled={disabled}
       title={title}
+      aria-label={title}
       className={cn(
-        'p-1.5 rounded-md text-sm transition-colors',
+        'p-1.5 rounded-md text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         active
           ? 'bg-accent text-accent-foreground'
           : 'hover:bg-accent/50 text-muted-foreground hover:text-foreground',
@@ -94,37 +108,135 @@ export function PageEditor({ page }: Props) {
   const { toast } = useToast()
   const router = useRouter()
   const saveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const isSavingRef = useRef(false)
+  const saveQueueRef = useRef<Promise<void>>(Promise.resolve())
+  const pendingSaveCountRef = useRef(0)
+  const latestRevisionRef = useRef(0)
+  const savedRevisionRef = useRef(0)
+  const latestContentRef = useRef<Record<string, unknown>>(
+    page.content ?? { type: 'doc', content: [] }
+  )
+  const latestTitleRef = useRef(page.title)
+  const titleDirtyRef = useRef(false)
+  const isMountedRef = useRef(true)
   const titleRef = useRef<HTMLInputElement>(null)
-  const saveAbortRef = useRef<AbortController | null>(null)
   const publishAbortRef = useRef<AbortController | null>(null)
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle')
+  const [saveError, setSaveError] = useState<string | null>(null)
 
-  const save = useCallback(
-    async (content: Record<string, unknown>, title?: string) => {
-      if (isSavingRef.current) return
-      isSavingRef.current = true
-      const controller = new AbortController()
-      saveAbortRef.current = controller
+  const enqueueSave = useCallback(
+    (request: SaveRequest): Promise<SaveResult> => {
+      pendingSaveCountRef.current += 1
 
-      try {
-        const body: Record<string, unknown> = { content }
-        if (title !== undefined) body.title = title
-        await fetch(`/api/pages/${page.id}`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-          signal: controller.signal,
-        })
-      } catch {
-        // silent auto-save failure
-      } finally {
-        if (saveAbortRef.current === controller) {
-          saveAbortRef.current = null
-        }
-        isSavingRef.current = false
+      if (isMountedRef.current) {
+        setSaveStatus('saving')
+        setSaveError(null)
       }
+
+      const run = async (): Promise<SaveResult> => {
+        try {
+          const body: Record<string, unknown> = { content: request.content }
+          if (request.title !== undefined) body.title = request.title
+
+          const response = await fetch(`/api/pages/${page.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+            keepalive: request.keepalive,
+          })
+
+          if (!response.ok) {
+            const data = (await response.json().catch(() => null)) as
+              | { error?: string; message?: string }
+              | null
+            throw new Error(
+              data?.error || data?.message || `Speichern fehlgeschlagen (${response.status})`
+            )
+          }
+
+          savedRevisionRef.current = Math.max(savedRevisionRef.current, request.revision)
+          if (
+            request.title !== undefined &&
+            request.title === latestTitleRef.current.trim()
+          ) {
+            titleDirtyRef.current = false
+          }
+          return { ok: true }
+        } catch (error) {
+          return {
+            ok: false,
+            error: error instanceof Error ? error.message : 'Unbekannter Fehler beim Speichern',
+          }
+        }
+      }
+
+      const task = saveQueueRef.current.then(run)
+      saveQueueRef.current = task.then(() => undefined)
+
+      void task.then((result) => {
+        pendingSaveCountRef.current = Math.max(0, pendingSaveCountRef.current - 1)
+        if (!isMountedRef.current) return
+
+        if (pendingSaveCountRef.current > 0) {
+          setSaveStatus('saving')
+          return
+        }
+
+        if (!result.ok && request.revision >= latestRevisionRef.current) {
+          setSaveStatus('error')
+          setSaveError(result.error)
+          return
+        }
+
+        if (
+          savedRevisionRef.current >= latestRevisionRef.current &&
+          !titleDirtyRef.current
+        ) {
+          setSaveStatus('saved')
+          setSaveError(null)
+          return
+        }
+
+        if (titleDirtyRef.current && !latestTitleRef.current.trim()) {
+          setSaveStatus('error')
+          setSaveError('Der Seitentitel darf nicht leer sein.')
+          return
+        }
+
+        setSaveStatus('saving')
+      })
+
+      return task
     },
     [page.id]
+  )
+
+  const scheduleAutosave = useCallback(
+    (content: Record<string, unknown>, title: string, titleChanged = false) => {
+      latestContentRef.current = content
+      latestTitleRef.current = title
+      if (titleChanged) titleDirtyRef.current = true
+      latestRevisionRef.current += 1
+
+      if (isMountedRef.current) {
+        setSaveStatus('saving')
+        setSaveError(null)
+      }
+
+      if (saveTimeout.current) clearTimeout(saveTimeout.current)
+      saveTimeout.current = setTimeout(() => {
+        saveTimeout.current = null
+        const normalizedTitle = latestTitleRef.current.trim()
+        const pendingTitle = titleDirtyRef.current && normalizedTitle
+          ? normalizedTitle
+          : undefined
+        void enqueueSave({
+          content: latestContentRef.current,
+          title: pendingTitle,
+          revision: latestRevisionRef.current,
+        })
+      }, 2000)
+    },
+    [enqueueSave]
   )
 
   const editor = useEditor({
@@ -146,14 +258,15 @@ export function PageEditor({ page }: Props) {
     ],
     content: page.content ?? undefined,
     onUpdate: ({ editor }) => {
-      if (saveTimeout.current) clearTimeout(saveTimeout.current)
-      saveTimeout.current = setTimeout(() => {
-        void save(editor.getJSON() as Record<string, unknown>)
-      }, 2000)
+      scheduleAutosave(
+        editor.getJSON() as Record<string, unknown>,
+        titleRef.current?.value ?? latestTitleRef.current
+      )
     },
     editorProps: {
       attributes: {
-        class: 'outline-none min-h-[400px] prose prose-sm dark:prose-invert max-w-none focus:outline-none',
+        'aria-label': 'Seiteninhalt',
+        class: 'min-h-[400px] max-w-none rounded-md outline-none prose prose-sm dark:prose-invert focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       },
       handleDrop: (view, event) => {
         const files = event.dataTransfer?.files
@@ -197,10 +310,47 @@ export function PageEditor({ page }: Props) {
 
   const handleManualSave = async () => {
     if (!editor) return
-    if (saveTimeout.current) clearTimeout(saveTimeout.current)
+    if (saveTimeout.current) {
+      clearTimeout(saveTimeout.current)
+      saveTimeout.current = null
+    }
+    latestContentRef.current = editor.getJSON() as Record<string, unknown>
     const title = titleRef.current?.value?.trim() ?? page.title
-    await save(editor.getJSON() as Record<string, unknown>, title)
-    toast({ title: 'Gespeichert ✓', description: 'Seite wurde gespeichert.' })
+    if (!title) {
+      setSaveStatus('error')
+      setSaveError('Der Seitentitel darf nicht leer sein.')
+      titleRef.current?.focus()
+      toast({
+        variant: 'destructive',
+        title: 'Titel fehlt',
+        description: 'Gib der Seite vor dem Speichern einen Titel.',
+      })
+      return
+    }
+    latestTitleRef.current = title
+    const result = await enqueueSave({
+      content: latestContentRef.current,
+      title,
+      revision: latestRevisionRef.current,
+    })
+
+    if (result.ok) {
+      const hasNewerChanges =
+        savedRevisionRef.current < latestRevisionRef.current || titleDirtyRef.current
+      toast({
+        title: hasNewerChanges ? 'Zwischenstand gespeichert' : 'Gespeichert ✓',
+        description: hasNewerChanges
+          ? 'Neuere Änderungen werden noch gespeichert.'
+          : 'Seite wurde gespeichert.',
+      })
+      return
+    }
+
+    toast({
+      variant: 'destructive',
+      title: 'Speichern fehlgeschlagen',
+      description: result.error,
+    })
   }
 
   const handlePublishToggle = async () => {
@@ -235,18 +385,54 @@ export function PageEditor({ page }: Props) {
 
   const handleTitleBlur = async () => {
     const title = titleRef.current?.value?.trim()
-    if (title && title !== page.title && editor) {
-      await save(editor.getJSON() as Record<string, unknown>, title)
+    if (!title && titleDirtyRef.current) {
+      setSaveStatus('error')
+      setSaveError('Der Seitentitel darf nicht leer sein.')
+      return
+    }
+    if (title && titleDirtyRef.current && editor) {
+      if (saveTimeout.current) {
+        clearTimeout(saveTimeout.current)
+        saveTimeout.current = null
+      }
+      latestContentRef.current = editor.getJSON() as Record<string, unknown>
+      latestTitleRef.current = title
+      titleDirtyRef.current = true
+      await enqueueSave({
+        content: latestContentRef.current,
+        title,
+        revision: latestRevisionRef.current,
+      })
     }
   }
 
   useEffect(() => {
+    isMountedRef.current = true
+
     return () => {
-      if (saveTimeout.current) clearTimeout(saveTimeout.current)
-      saveAbortRef.current?.abort()
+      isMountedRef.current = false
+
+      if (saveTimeout.current) {
+        clearTimeout(saveTimeout.current)
+        saveTimeout.current = null
+      }
+
+      if (savedRevisionRef.current < latestRevisionRef.current) {
+        const normalizedTitle = latestTitleRef.current.trim()
+        const pendingTitle = titleDirtyRef.current && normalizedTitle
+          ? normalizedTitle
+          : undefined
+        void enqueueSave({
+          content: latestContentRef.current,
+          title: pendingTitle,
+          revision: latestRevisionRef.current,
+          keepalive: true,
+        })
+      }
+
       publishAbortRef.current?.abort()
     }
-  }, [])
+  }, [enqueueSave])
 
   if (!editor) return null
 
@@ -276,13 +462,31 @@ export function PageEditor({ page }: Props) {
             </Button>
           </div>
         </div>
+        <label htmlFor="page-editor-title" className="sr-only">
+          Seitentitel
+        </label>
         <input
+          id="page-editor-title"
           ref={titleRef}
           defaultValue={page.title}
+          onChange={(event) => {
+            scheduleAutosave(latestContentRef.current, event.currentTarget.value, true)
+          }}
           onBlur={handleTitleBlur}
-          className="w-full text-3xl font-bold bg-transparent border-none outline-none placeholder:text-muted-foreground/50 py-2"
+          className="w-full rounded-md bg-transparent py-2 text-3xl font-bold outline-none placeholder:text-muted-foreground/50 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           placeholder="Titel..."
         />
+        <div aria-live="polite" aria-atomic="true" className="min-h-5">
+          {saveStatus === 'saving' ? (
+            <p className="text-xs text-muted-foreground">Speichert…</p>
+          ) : saveStatus === 'saved' ? (
+            <p className="text-xs text-emerald-700">Alle Änderungen gespeichert.</p>
+          ) : saveStatus === 'error' ? (
+            <p className="text-xs text-red-700" role="alert">
+              Speichern fehlgeschlagen: {saveError}
+            </p>
+          ) : null}
+        </div>
       </div>
 
       {/* Sticky toolbar */}

--- a/components/sections/cta-section-1.tsx
+++ b/components/sections/cta-section-1.tsx
@@ -7,7 +7,7 @@ import { Card } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { VortexBackground } from "@/components/ui/vortex-wrapper"
 import { trackConversion } from '@/components/analytics/tracking'
-import { MENTORSHIP_CONFIG } from '@/lib/config'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 
 export default function CTASection() {
   const { isSignedIn } = useUser()
@@ -47,8 +47,9 @@ export default function CTASection() {
                   Bereit dein Trading zu transformieren?
                 </h2>
                 <p className="text-base sm:text-lg opacity-90 mb-6">
-                  Trete jetzt der Warteliste bei und sichere dir als einer der Ersten deinen Platz
-                  im Mentorship Programm 2026.
+                  {MENTORSHIP_IS_UPCOMING
+                    ? 'Trete jetzt der Warteliste bei und sichere dir als einer der Ersten deinen Platz im Mentorship Programm 2026.'
+                    : 'Steige in die laufende Mentorship 2026 ein, solange noch ein Platz verfügbar ist.'}
                 </p>
                 {isSignedIn ? (
                   <Button 
@@ -81,15 +82,21 @@ export default function CTASection() {
                   </p>
                 </div>
                 <div className="bg-white/5 backdrop-blur-sm rounded-lg p-3 sm:p-4 border border-white/10">
-                  <p className="text-sm sm:text-base font-medium">🚀 Start im {MENTORSHIP_CONFIG.startMonthYear}</p>
+                  <p className="text-sm sm:text-base font-medium">
+                    🚀 {MENTORSHIP_IS_UPCOMING ? `Start im ${MENTORSHIP_CONFIG.startMonthYear}` : MENTORSHIP_CONFIG.enrollmentLabel}
+                  </p>
                   <p className="text-xs sm:text-sm opacity-90">
                     Die Vergabe der Plätze erfolgt nach dem Prinzip: Wer zuerst kommt, mahlt zuerst.
                   </p>
                 </div>
                 <div className="bg-white/5 backdrop-blur-sm rounded-lg p-3 sm:p-4 border border-white/10">
-                  <p className="text-sm sm:text-base font-medium">💎 Kostenlose Reservierung</p>
+                  <p className="text-sm sm:text-base font-medium">
+                    💎 {MENTORSHIP_IS_UPCOMING ? 'Kostenlose Reservierung' : 'Flexibles Monatsabo'}
+                  </p>
                   <p className="text-xs sm:text-sm opacity-90">
-                    Dein Zahlungsmittel wird erst beim Start der Mentorship mit {MENTORSHIP_CONFIG.price}€/Monat (inkl. MwSt.) belastet. Du kannst jederzeit kündigen.
+                    {MENTORSHIP_IS_UPCOMING
+                      ? `Dein Zahlungsmittel wird erst beim Start der Mentorship mit ${MENTORSHIP_CONFIG.price}€/Monat (inkl. MwSt.) belastet. Du kannst jederzeit kündigen.`
+                      : `${MENTORSHIP_CONFIG.price}€/Monat (inkl. MwSt.). Du kannst jederzeit kündigen.`}
                   </p>
                 </div>
               </div>

--- a/components/sections/faq.tsx
+++ b/components/sections/faq.tsx
@@ -1,10 +1,14 @@
-import { MENTORSHIP_CONFIG } from '@/lib/config'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 
 const faqs = [
   {
     id: "item-1",
-    question: `Warum startet das Programm im ${MENTORSHIP_CONFIG.startMonthYear}?`,
-    answer: `Der Start am ${MENTORSHIP_CONFIG.startDateFormatted} ermöglicht es mir, alle Teilnehmer einzusammeln und sicherzustellen, dass alle gemeinsam beginnen, um von Tag eins an eine starke Community aufzubauen. Dies gibt dir auch die Zeit, deinen Platz zu sichern und dich auf das Programm vorzubereiten.`,
+    question: MENTORSHIP_IS_UPCOMING
+      ? `Warum startet das Programm im ${MENTORSHIP_CONFIG.startMonthYear}?`
+      : 'Kann ich noch in die Mentorship 2026 einsteigen?',
+    answer: MENTORSHIP_IS_UPCOMING
+      ? `Der Start am ${MENTORSHIP_CONFIG.startDateFormatted} ermöglicht es mir, alle Teilnehmer einzusammeln und sicherzustellen, dass alle gemeinsam beginnen, um von Tag eins an eine starke Community aufzubauen. Dies gibt dir auch die Zeit, deinen Platz zu sichern und dich auf das Programm vorzubereiten.`
+      : 'Ja, solange noch ein Platz verfügbar ist. Nach der Freischaltung erhältst du direkten Zugang zum laufenden Programm, zu den bisherigen Aufzeichnungen und zur Community.',
   },
   {
     id: "item-2",

--- a/components/sections/final-cta.tsx
+++ b/components/sections/final-cta.tsx
@@ -12,7 +12,7 @@ import { useUser, SignInButton } from '@clerk/nextjs'
 import { useRouter } from 'next/navigation'
 import { trackConversion } from '@/components/analytics/tracking'
 import { useMediaQuery } from "@/hooks/use-media-query"
-import { MENTORSHIP_CONFIG } from '@/lib/config'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 
 const Vortex = dynamic(
     () => import("@/components/ui/vortex").then((mod) => mod.Vortex),
@@ -182,7 +182,7 @@ export default function FinalCTA() {
                         <h2 className="text-2xl sm:text-4xl md:text-5xl font-bold text-white mb-4 sm:mb-6">
                             Deine Trading-Reise <br />
                             <span className="text-blue-400">
-                                Beginnt im {MENTORSHIP_CONFIG.startMonthYear}
+                                {MENTORSHIP_IS_UPCOMING ? `Beginnt im ${MENTORSHIP_CONFIG.startMonthYear}` : 'Beginnt jetzt'}
                             </span>
                         </h2>
                         <p className="text-sm sm:text-xl text-gray-300 max-w-2xl mx-auto">
@@ -191,12 +191,18 @@ export default function FinalCTA() {
                         </p>
                     </div>
                     <div className="mt-6 sm:mt-8 flex justify-center">
-                        <div className="max-w-md w-full">
-                            <p className="text-xs sm:text-sm text-gray-200 mb-2 sm:mb-3">
-                                Verbleibende Zeit zur Anmeldung in die Warteliste
+                        {MENTORSHIP_IS_UPCOMING ? (
+                            <div className="max-w-md w-full">
+                                <p className="text-xs sm:text-sm text-gray-200 mb-2 sm:mb-3">
+                                    Verbleibende Zeit zur Anmeldung in die Warteliste
+                                </p>
+                                <Countdown targetDate={MENTORSHIP_CONFIG.startDate} variant="dark" />
+                            </div>
+                        ) : (
+                            <p className="rounded-full border border-blue-400/30 bg-blue-400/10 px-4 py-2 text-sm font-medium text-blue-200">
+                                {MENTORSHIP_CONFIG.enrollmentLabel}
                             </p>
-                            <Countdown targetDate={MENTORSHIP_CONFIG.startDate} variant="dark" />
-                        </div>
+                        )}
                     </div>
                 </div>
 
@@ -235,7 +241,7 @@ export default function FinalCTA() {
                     {ctaButton}
                     
                     <p className="mt-4 sm:mt-6 text-xs sm:text-base text-gray-400">
-                        Keine Zahlung bis zum Programmstart.
+                        {MENTORSHIP_IS_UPCOMING ? 'Keine Zahlung bis zum Programmstart.' : MENTORSHIP_CONFIG.paymentNote}
                     </p>
 
                     <div className="mt-6 sm:mt-12 inline-flex items-center gap-1.5 sm:gap-2 pl-1.5 sm:pl-2 pr-3 sm:pr-4 py-1 rounded-full bg-white/10 ring-1 ring-white/20">

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -17,7 +17,7 @@ import { SignInButton, useUser } from '@clerk/nextjs'
 import { useRouter } from 'next/navigation'
 import { trackConversion } from '@/components/analytics/tracking'
 import { HeroPill } from '@/components/ui/hero-pill'
-import { MENTORSHIP_CONFIG } from '@/lib/config'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 import { getWhopReviewStats } from '@/lib/whop-review-stats'
 
 const GLSLHills = dynamic(
@@ -34,11 +34,8 @@ const ParticleTextReveal = dynamic(
 )
 
 export default function Hero() {
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
   const containerRef = useRef<HTMLDivElement>(null)
-  const mouseFrameRef = useRef<number | null>(null)
   const navigationTimeoutRef = useRef<number | null>(null)
-  const latestMouseRef = useRef<{ clientX: number; clientY: number } | null>(null)
   const isMobile = useMediaQuery("(max-width: 768px)")
   const [isNavigating, setIsNavigating] = useState(false)
   const [isInView, setIsInView] = useState(false)
@@ -46,37 +43,6 @@ export default function Hero() {
   const { isSignedIn } = useUser()
   const router = useRouter()
   const [whopStats, setWhopStats] = useState<{ count: number; average: number } | null>(null)
-
-  useEffect(() => {
-    if (!isMobile && isInView) {
-      const handleMouseMove = (e: MouseEvent) => {
-        latestMouseRef.current = { clientX: e.clientX, clientY: e.clientY }
-
-        if (mouseFrameRef.current != null) return
-
-        mouseFrameRef.current = window.requestAnimationFrame(() => {
-          mouseFrameRef.current = null
-          const latestMouse = latestMouseRef.current
-          if (!latestMouse || !containerRef.current) return
-
-          const rect = containerRef.current.getBoundingClientRect()
-          setMousePosition({
-            x: latestMouse.clientX - rect.left,
-            y: latestMouse.clientY - rect.top + window.scrollY
-          })
-        })
-      }
-
-      window.addEventListener('mousemove', handleMouseMove)
-      return () => {
-        window.removeEventListener('mousemove', handleMouseMove)
-        if (mouseFrameRef.current != null) {
-          window.cancelAnimationFrame(mouseFrameRef.current)
-          mouseFrameRef.current = null
-        }
-      }
-    }
-  }, [isMobile, isInView])
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -266,7 +232,11 @@ export default function Hero() {
                   variant="blue"
                   size="sm"
                   announcement="🚀"
-                  label={`Limitiert auf ${MENTORSHIP_CONFIG.maxSpots} Plätze • Start am ${MENTORSHIP_CONFIG.startDateFormatted}`}
+                  label={
+                    MENTORSHIP_IS_UPCOMING
+                      ? `Limitiert auf ${MENTORSHIP_CONFIG.maxSpots} Plätze • Start am ${MENTORSHIP_CONFIG.startDateFormatted}`
+                      : MENTORSHIP_CONFIG.enrollmentLabel
+                  }
                 />
               </div>
               <h1 className="hidden lg:block text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight text-gray-900 lg:leading-[1.1]">
@@ -340,14 +310,15 @@ export default function Hero() {
                 </div>
               </div>
 
-              <div className="pt-3 hidden lg:block text-left">
-                
-                <div className="inline-flex items-center gap-1.5 sm:gap-2 pl-1.5 sm:pl-2 pr-3 sm:pr-4 py-1 rounded-full bg-blue-50 ring-1 ring-blue-200 mb-3">
-                  <div className="bg-blue-100 text-blue-700 rounded-full px-2 py-0.5 text-xs sm:text-sm">⏰</div>
-                  <span className="text-xs sm:text-sm font-medium text-blue-700">Verbleibende Zeit zur Einschreibung</span>
+              {MENTORSHIP_IS_UPCOMING ? (
+                <div className="pt-3 hidden lg:block text-left">
+                  <div className="inline-flex items-center gap-1.5 sm:gap-2 pl-1.5 sm:pl-2 pr-3 sm:pr-4 py-1 rounded-full bg-blue-50 ring-1 ring-blue-200 mb-3">
+                    <div className="bg-blue-100 text-blue-700 rounded-full px-2 py-0.5 text-xs sm:text-sm">⏰</div>
+                    <span className="text-xs sm:text-sm font-medium text-blue-700">Verbleibende Zeit zur Einschreibung</span>
+                  </div>
+                  <Countdown targetDate={MENTORSHIP_CONFIG.startDate} />
                 </div>
-                <Countdown targetDate={MENTORSHIP_CONFIG.startDate} />
-              </div>
+              ) : null}
             </div>
 
             {/* Right Column - Visual Element */}
@@ -446,16 +417,22 @@ export default function Hero() {
                     size="sm"
                     className="w-full justify-center"
                     announcement="🚀"
-                    label={`Limitiert auf ${MENTORSHIP_CONFIG.maxSpots} Plätze • Start am ${MENTORSHIP_CONFIG.startDateFormatted}`}
+                    label={
+                      MENTORSHIP_IS_UPCOMING
+                        ? `Limitiert auf ${MENTORSHIP_CONFIG.maxSpots} Plätze • Start am ${MENTORSHIP_CONFIG.startDateFormatted}`
+                        : MENTORSHIP_CONFIG.enrollmentLabel
+                    }
                   />
                 </div>
 
-                <div className="mt-4 lg:hidden text-center">
-                  <p className="text-xs text-gray-700 mb-2">
-                    Verbleibende Zeit zur Einschreibung in die Warteliste
-                  </p>
-                  <Countdown targetDate={MENTORSHIP_CONFIG.startDate} />
-                </div>
+                {MENTORSHIP_IS_UPCOMING ? (
+                  <div className="mt-4 lg:hidden text-center">
+                    <p className="text-xs text-gray-700 mb-2">
+                      Verbleibende Zeit zur Einschreibung in die Warteliste
+                    </p>
+                    <Countdown targetDate={MENTORSHIP_CONFIG.startDate} />
+                  </div>
+                ) : null}
 
                 <div className="mt-2 flex flex-col items-center lg:grid lg:grid-cols-2 gap-3 lg:items-stretch">
                   <a

--- a/components/sections/hormozi-landing.tsx
+++ b/components/sections/hormozi-landing.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
 import { Countdown } from '@/components/ui/countdown'
-import { MENTORSHIP_CONFIG } from '@/lib/config'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 import { HormoziLandingCtaButton } from '@/components/sections/hormozi-landing-cta-button'
 
 export default function HormoziLanding() {
@@ -169,14 +169,20 @@ export default function HormoziLanding() {
             Du bekommst 2–3 Live‑Sessions pro Woche. Du kommst rein, indem du dich anmeldest.
           </p>
           <div className="mt-6 flex justify-center">
-            <div className="max-w-sm">
-              <p className="text-[11px] text-slate-500">Anmeldung schließt in</p>
-              <Countdown
-                targetDate={MENTORSHIP_CONFIG.startDate}
-                variant="light"
-                className="mt-2 scale-75 sm:scale-90 sm:[&>div]:flex-nowrap"
-              />
-            </div>
+            {MENTORSHIP_IS_UPCOMING ? (
+              <div className="max-w-sm">
+                <p className="text-[11px] text-slate-500">Anmeldung schließt in</p>
+                <Countdown
+                  targetDate={MENTORSHIP_CONFIG.startDate}
+                  variant="light"
+                  className="mt-2 scale-75 sm:scale-90 sm:[&>div]:flex-nowrap"
+                />
+              </div>
+            ) : (
+              <p className="rounded-full border border-blue-200 bg-blue-50 px-4 py-2 text-xs font-medium text-blue-700">
+                {MENTORSHIP_CONFIG.enrollmentLabel}
+              </p>
+            )}
           </div>
           <div className="mt-7 space-y-3">
             <HormoziLandingCtaButton

--- a/components/sections/lazy-final-cta-section.tsx
+++ b/components/sections/lazy-final-cta-section.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic'
 import { useEffect, useRef, useState } from 'react'
-import { MENTORSHIP_CONFIG } from '@/lib/config'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 
 const FinalCTA = dynamic(() => import('@/components/sections/final-cta'), {
   ssr: false,
@@ -29,7 +29,7 @@ export default function LazyFinalCtaSection() {
           observer.disconnect()
         }
       },
-      { rootMargin: '1600px 0px' }
+      { rootMargin: '600px 0px' }
     )
 
     observer.observe(node)
@@ -57,7 +57,9 @@ function FinalCtaFallback() {
           </div>
           <h2 className="text-2xl sm:text-4xl md:text-5xl font-bold text-white mb-4 sm:mb-6">
             Deine Trading-Reise <br />
-            <span className="text-blue-400">Beginnt im {MENTORSHIP_CONFIG.startMonthYear}</span>
+            <span className="text-blue-400">
+              {MENTORSHIP_IS_UPCOMING ? `Beginnt im ${MENTORSHIP_CONFIG.startMonthYear}` : 'Beginnt jetzt'}
+            </span>
           </h2>
           <p className="text-sm sm:text-xl text-gray-300 max-w-2xl mx-auto">
             Werde einer von {MENTORSHIP_CONFIG.maxSpots} ambitionierten Tradern und erlebe ein transformatives Jahr
@@ -65,21 +67,27 @@ function FinalCtaFallback() {
           </p>
         </div>
 
-        <div className="mx-auto mb-12 grid max-w-md grid-cols-2 gap-2 text-center sm:grid-cols-4">
-          {['Tage', 'Std', 'Min', 'Sek'].map((label) => (
-            <div key={label} className="rounded-md border border-slate-700 bg-slate-900/80 px-4 py-3 text-slate-100">
-              <div className="text-xl font-bold">00</div>
-              <div className="text-xs uppercase tracking-wide text-slate-400">{label}</div>
-            </div>
-          ))}
-        </div>
+        {MENTORSHIP_IS_UPCOMING ? (
+          <div className="mx-auto mb-12 grid max-w-md grid-cols-2 gap-2 text-center sm:grid-cols-4">
+            {['Tage', 'Std', 'Min', 'Sek'].map((label) => (
+              <div key={label} className="rounded-md border border-slate-700 bg-slate-900/80 px-4 py-3 text-slate-100">
+                <div className="text-xl font-bold">00</div>
+                <div className="text-xs uppercase tracking-wide text-slate-400">{label}</div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="mx-auto mb-12 w-fit rounded-full border border-blue-400/30 bg-blue-400/10 px-4 py-2 text-sm font-medium text-blue-200">
+            {MENTORSHIP_CONFIG.enrollmentLabel}
+          </p>
+        )}
 
         <div className="text-center">
           <div className="inline-flex h-12 items-center justify-center rounded-md bg-white/90 px-6 text-sm font-medium text-slate-900 sm:h-14 sm:px-8 sm:text-lg">
             Prüfen ob Plätze frei sind
           </div>
           <p className="mt-4 sm:mt-6 text-xs sm:text-base text-gray-400">
-            Keine Zahlung bis zum Programmstart.
+            {MENTORSHIP_IS_UPCOMING ? 'Keine Zahlung bis zum Programmstart.' : MENTORSHIP_CONFIG.paymentNote}
           </p>
         </div>
       </div>

--- a/components/sections/lazy-testimonials-section.tsx
+++ b/components/sections/lazy-testimonials-section.tsx
@@ -33,7 +33,7 @@ export default function LazyTestimonialsSection() {
           observer.disconnect()
         }
       },
-      { rootMargin: '1200px 0px' }
+      { rootMargin: '500px 0px' }
     )
 
     observer.observe(node)

--- a/components/sections/lead-magnet-countdown.tsx
+++ b/components/sections/lead-magnet-countdown.tsx
@@ -14,13 +14,15 @@ type TimeParts = {
   hours: number
   minutes: number
   seconds: number
+  expired: boolean
 }
 
 const pad = (value: number) => value.toString().padStart(2, '0')
 
 const getTimeParts = (target: Date): TimeParts => {
   const now = new Date()
-  const diffMs = Math.max(0, target.getTime() - now.getTime())
+  const targetMs = target.getTime()
+  const diffMs = Number.isFinite(targetMs) ? Math.max(0, targetMs - now.getTime()) : 0
   const totalSeconds = Math.floor(diffMs / 1000)
 
   const days = Math.floor(totalSeconds / 86400)
@@ -28,7 +30,7 @@ const getTimeParts = (target: Date): TimeParts => {
   const minutes = Math.floor((totalSeconds % 3600) / 60)
   const seconds = totalSeconds % 60
 
-  return { days, hours, minutes, seconds }
+  return { days, hours, minutes, seconds, expired: diffMs <= 0 }
 }
 
 export default function LeadMagnetCountdown({
@@ -42,7 +44,9 @@ export default function LeadMagnetCountdown({
     let interval: number | null = null
 
     const update = () => {
-      setTimeLeft(getTimeParts(target))
+      const next = getTimeParts(target)
+      setTimeLeft(next)
+      return next.expired
     }
 
     const stop = () => {
@@ -54,10 +58,12 @@ export default function LeadMagnetCountdown({
 
     const start = () => {
       stop()
-      update()
+      const expired = update()
 
-      if (document.visibilityState === 'visible') {
-        interval = window.setInterval(update, 1000)
+      if (!expired && document.visibilityState === 'visible') {
+        interval = window.setInterval(() => {
+          if (update()) stop()
+        }, 1000)
       }
     }
 
@@ -78,7 +84,7 @@ export default function LeadMagnetCountdown({
     }
   }, [target])
 
-  if (!timeLeft) {
+  if (!timeLeft || timeLeft.expired) {
     return null
   }
 

--- a/components/sections/lead-magnet-hero.tsx
+++ b/components/sections/lead-magnet-hero.tsx
@@ -58,7 +58,7 @@ export default function LeadMagnetHero() {
                 </div>
               </div>
             </GlassCard>
-            <div id="lead-magnet-inline-form">
+            <div id="lead-magnet-inline-form-mobile">
               <GlassCard>
                 <p className="text-pretty text-sm font-medium text-neutral-900">
                   Starte Jetzt Kostenlos
@@ -69,7 +69,7 @@ export default function LeadMagnetHero() {
                 <Suspense fallback={null}>
                   <LeadMagnetSignupForm
                     className="mt-4"
-                    idPrefix="lead-magnet-inline"
+                    idPrefix="lead-magnet-inline-mobile"
                     socialProof={<LeadMagnetWhopPill />}
                   />
                 </Suspense>
@@ -94,7 +94,7 @@ export default function LeadMagnetHero() {
               kannst. Keine unnötige Theorie, nur das, was zählt: Modell,
               Trading‑Plan und Checkliste.
             </p>
-            <div className="mt-8 max-w-sm" id="lead-magnet-inline-form">
+            <div className="mt-8 max-w-sm" id="lead-magnet-inline-form-desktop">
               <GlassCard>
                 <p className="text-pretty text-sm font-medium text-neutral-900">
                   Starte Jetzt Kostenlos
@@ -105,7 +105,7 @@ export default function LeadMagnetHero() {
                 <Suspense fallback={null}>
                   <LeadMagnetSignupForm
                     className="mt-4"
-                    idPrefix="lead-magnet-inline"
+                    idPrefix="lead-magnet-inline-desktop"
                     socialProof={<LeadMagnetWhopPill />}
                   />
                 </Suspense>

--- a/components/sections/raidmap/success-dialog.tsx
+++ b/components/sections/raidmap/success-dialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
@@ -37,14 +37,8 @@ const copy = {
 
 export function RaidMapSuccessDialog({ lang, hasGuideImage }: { lang: RaidMapLang; hasGuideImage: boolean }) {
   const searchParams = useSearchParams()
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(() => searchParams.get('checkout') === 'success')
   const t = copy[lang]
-
-  useEffect(() => {
-    if (searchParams.get('checkout') === 'success') {
-      setOpen(true)
-    }
-  }, [searchParams])
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>

--- a/components/sections/waitlist-cta.tsx
+++ b/components/sections/waitlist-cta.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { MENTORSHIP_CONFIG } from '@/lib/config'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { Vortex } from "@/components/ui/vortex"
@@ -32,11 +32,12 @@ export default function WaitlistCTA() {
                     Ready to Transform Your Career?
                   </h2>
                   <p className="text-lg opacity-90 mb-6">
-                    Join our waitlist today and be among the first to secure your spot
-                    in our 2026 Mentorship Program.
+                    {MENTORSHIP_IS_UPCOMING
+                      ? 'Join our waitlist today and be among the first to secure your spot in our 2026 Mentorship Program.'
+                      : 'Join the current 2026 Mentorship Program while places are still available.'}
                   </p>
                   <Button size="lg" variant="secondary" className="w-full sm:w-auto">
-                    Join Waitlist Now
+                    {MENTORSHIP_IS_UPCOMING ? 'Join Waitlist Now' : 'Check Availability'}
                   </Button>
                 </div>
                 <div className="space-y-6">
@@ -47,15 +48,17 @@ export default function WaitlistCTA() {
                     </p>
                   </div>
                   <div className="bg-black/10 backdrop-blur-sm rounded-lg p-4">
-                    <p className="font-medium">🚀 Program starts {MENTORSHIP_CONFIG.startMonthYear}</p>
+                    <p className="font-medium">
+                      🚀 {MENTORSHIP_IS_UPCOMING ? `Program starts ${MENTORSHIP_CONFIG.startMonthYear}` : MENTORSHIP_CONFIG.enrollmentLabelEn}
+                    </p>
                     <p className="text-sm opacity-90">
-                      Early waitlist members get priority access
+                      {MENTORSHIP_IS_UPCOMING ? 'Early waitlist members get priority access' : 'Get access after your place is confirmed'}
                     </p>
                   </div>
                   <div className="bg-black/10 backdrop-blur-sm rounded-lg p-4">
-                    <p className="font-medium">💎 No payment until program starts</p>
+                    <p className="font-medium">💎 {MENTORSHIP_IS_UPCOMING ? 'No payment until program starts' : 'Flexible monthly membership'}</p>
                     <p className="text-sm opacity-90">
-                      Secure your spot now, pay when the program begins
+                      {MENTORSHIP_IS_UPCOMING ? 'Secure your spot now, pay when the program begins' : 'Monthly billing with the option to cancel'}
                     </p>
                   </div>
                 </div>

--- a/components/ui/countdown.tsx
+++ b/components/ui/countdown.tsx
@@ -1,18 +1,28 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 
 type CountdownProps = {
   targetDate: string
   className?: string
   variant?: 'light' | 'dark'
+  expiredFallback?: ReactNode
+}
+
+type TimeParts = {
+  days: number
+  hours: number
+  minutes: number
+  seconds: number
+  expired: boolean
 }
 
 const pad = (value: number) => value.toString().padStart(2, '0')
 
 const getTimeParts = (target: Date) => {
   const now = new Date()
-  const diffMs = Math.max(0, target.getTime() - now.getTime())
+  const targetMs = target.getTime()
+  const diffMs = Number.isFinite(targetMs) ? Math.max(0, targetMs - now.getTime()) : 0
   const totalSeconds = Math.floor(diffMs / 1000)
 
   const days = Math.floor(totalSeconds / 86400)
@@ -20,14 +30,14 @@ const getTimeParts = (target: Date) => {
   const minutes = Math.floor((totalSeconds % 3600) / 60)
   const seconds = totalSeconds % 60
 
-  return { days, hours, minutes, seconds }
+  return { days, hours, minutes, seconds, expired: diffMs <= 0 }
 }
 
-export function Countdown({ targetDate, className, variant = 'light' }: CountdownProps) {
+export function Countdown({ targetDate, className, variant = 'light', expiredFallback = null }: CountdownProps) {
   const target = useMemo(() => new Date(targetDate), [targetDate])
   // Starte mit null, um Hydration-Mismatch zu vermeiden
-  const [timeLeft, setTimeLeft] = useState<{ days: number; hours: number; minutes: number; seconds: number } | null>(null)
-  const prevRef = useRef<{ days: number; hours: number; minutes: number; seconds: number } | null>(null)
+  const [timeLeft, setTimeLeft] = useState<TimeParts | null>(null)
+  const prevRef = useRef<TimeParts | null>(null)
   const [pulse, setPulse] = useState({ days: false, hours: false, minutes: false, seconds: false })
 
   useEffect(() => {
@@ -46,6 +56,7 @@ export function Countdown({ targetDate, className, variant = 'light' }: Countdow
         if (next.seconds !== prev.seconds) setPulse((curr) => ({ ...curr, seconds: true }))
       }
       prevRef.current = next
+      return next.expired
     }
 
     const stop = () => {
@@ -57,10 +68,12 @@ export function Countdown({ targetDate, className, variant = 'light' }: Countdow
 
     const start = () => {
       stop()
-      update()
+      const expired = update()
 
-      if (document.visibilityState === 'visible') {
-        interval = window.setInterval(update, 1000)
+      if (!expired && document.visibilityState === 'visible') {
+        interval = window.setInterval(() => {
+          if (update()) stop()
+        }, 1000)
       }
     }
 
@@ -96,8 +109,12 @@ export function Countdown({ targetDate, className, variant = 'light' }: Countdow
     ? 'bg-amber-900/30 border-amber-500/40 ring-1 ring-amber-500/30'
     : 'bg-amber-50/80 border-amber-200 ring-1 ring-amber-200/70'
 
-   // Zeige Platzhalter während SSR/Hydration
-  const display = timeLeft ?? { days: 0, hours: 0, minutes: 0, seconds: 0 }
+  if (timeLeft?.expired) {
+    return expiredFallback ? <div className={className}>{expiredFallback}</div> : null
+  }
+
+  // Zeige Platzhalter während SSR/Hydration
+  const display = timeLeft ?? { days: 0, hours: 0, minutes: 0, seconds: 0, expired: false }
 
   return (
     <div className={className}>

--- a/components/ui/infinite-scroll.tsx
+++ b/components/ui/infinite-scroll.tsx
@@ -18,12 +18,13 @@ export default function InfiniteScroll({
   gap = 16
 }: InfiniteScrollProps) {
   const isHoveredRef = useRef(false)
+  const isFocusWithinRef = useRef(false)
   const initializedRef = useRef(false)
   const containerRef = useRef<HTMLDivElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const sequenceWidthRef = useRef(0)
   const positionRef = useRef(0)
-  const animationFrameRef = useRef<number>()
+  const animationFrameRef = useRef<number | null>(null)
   const lastTimeRef = useRef<number>(0)
   const velocityRef = useRef(0)
   const targetVelocityRef = useRef(0)
@@ -138,7 +139,7 @@ export default function InfiniteScroll({
         return
       }
       
-      const isPaused = pauseOnHover && isHoveredRef.current
+      const isPaused = (pauseOnHover && isHoveredRef.current) || isFocusWithinRef.current
       targetVelocityRef.current = isPaused ? 0 : (direction === 'left' ? -speed : speed)
       velocityRef.current += (targetVelocityRef.current - velocityRef.current) * 0.1
 
@@ -163,8 +164,9 @@ export default function InfiniteScroll({
     animationFrameRef.current = requestAnimationFrame(animate)
 
     return () => {
-      if (animationFrameRef.current) {
+      if (animationFrameRef.current !== null) {
         cancelAnimationFrame(animationFrameRef.current)
+        animationFrameRef.current = null
       }
     }
   }, [direction, speed, pauseOnHover, baseCount, isInView, isDocumentVisible, prefersReducedMotion])
@@ -173,6 +175,15 @@ export default function InfiniteScroll({
     <div
       ref={containerRef}
       className={`relative overflow-hidden ${className}`} // Removed h-full and w-full
+      onFocusCapture={() => {
+        isFocusWithinRef.current = true
+        velocityRef.current = 0
+      }}
+      onBlurCapture={(event) => {
+        if (event.currentTarget.contains(event.relatedTarget as Node | null)) return
+        isFocusWithinRef.current = false
+        velocityRef.current = 0
+      }}
     >
       <div
         ref={scrollRef}
@@ -183,23 +194,31 @@ export default function InfiniteScroll({
           willChange: 'transform',
         }}
       >
-        {items.map((child, index) => (
-          <div
-            key={index}
-            className="flex-shrink-0"
-            onMouseEnter={() => {
-              if (!pauseOnHover) return
-              isHoveredRef.current = true
-            }}
-            onMouseLeave={() => {
-              if (!pauseOnHover) return
-              isHoveredRef.current = false
-              velocityRef.current = 0
-            }}
-          >
-            {child}
-          </div>
-        ))}
+        {items.map((child, index) => {
+          // Right-moving rows start at -sequenceWidth, so their visible and
+          // focusable sequence is the second copy rather than the first.
+          const isDuplicate = direction === 'right' ? index < baseCount : index >= baseCount
+
+          return (
+            <div
+              key={index}
+              className="flex-shrink-0"
+              aria-hidden={isDuplicate ? true : undefined}
+              inert={isDuplicate ? true : undefined}
+              onMouseEnter={() => {
+                if (!pauseOnHover) return
+                isHoveredRef.current = true
+              }}
+              onMouseLeave={() => {
+                if (!pauseOnHover) return
+                isHoveredRef.current = false
+                velocityRef.current = 0
+              }}
+            >
+              {child}
+            </div>
+          )
+        })}
       </div>
     </div>
   )

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,6 +1,8 @@
 // Zentrale Konfiguration für PAT Mentorship
 // Änderungen hier wirken sich auf die gesamte Website aus.
 
+export type MentorshipEnrollmentPhase = 'upcoming' | 'active'
+
 export const MENTORSHIP_CONFIG = {
   // Pricing
   price: 150,
@@ -15,10 +17,16 @@ export const MENTORSHIP_CONFIG = {
   startDate: '2026-03-01T00:00:00+01:00',
   startDateFormatted: '01.03.2026',
   startMonthYear: 'März 2026',
+  enrollmentPhase: 'active' as MentorshipEnrollmentPhase,
+  enrollmentLabel: 'Laufender Jahrgang • Einstieg nach Verfügbarkeit',
+  enrollmentLabelEn: 'Program in progress • Entry subject to availability',
+  paymentNote: 'Monatlich kündbar. Zugang nach erfolgreicher Freischaltung.',
 
   // Content
   sessionsPerWeek: '2',
   sessionDays: 'Di + Do',
 } as const
+
+export const MENTORSHIP_IS_UPCOMING = MENTORSHIP_CONFIG.enrollmentPhase === 'upcoming'
 
 export type MentorshipConfig = typeof MENTORSHIP_CONFIG

--- a/lib/indicators/store.ts
+++ b/lib/indicators/store.ts
@@ -1033,20 +1033,23 @@ export async function claimIndicatorForUser(input: {
       // das fehl, bleibt "Manage access" der manuelle Fallback (Telegram).
       const revalidation = await new TradingViewService().validateUsername(requestedTvUsername)
       if (!revalidation.valid) {
+        const validationUnavailable = revalidation.reason === 'unavailable'
         await writeClaimAudit({
           userId: input.userId,
           indicatorId: input.indicatorId,
           tvUsername: requestedTvUsername,
           action: 'claim',
           result: 'failure',
-          errorCode: 'invalid_username',
-          metadata: { reason: 'rebind_validation' },
+          errorCode: validationUnavailable ? 'username_validation_unavailable' : 'invalid_username',
+          metadata: { reason: validationUnavailable ? 'rebind_validation_unavailable' : 'rebind_validation' },
         })
         return {
           ok: false,
           indicatorId: input.indicatorId,
           tvUsername: requestedTvUsername,
-          message: `TradingView-Benutzername "${requestedTvUsername}" wurde nicht gefunden.`,
+          message: validationUnavailable
+            ? 'TradingView konnte den Benutzernamen gerade nicht prüfen. Bitte versuche es in einem Moment erneut.'
+            : `TradingView-Benutzername "${requestedTvUsername}" wurde nicht gefunden.`,
         }
       }
 
@@ -1141,23 +1144,26 @@ export async function claimIndicatorForUser(input: {
   }
 
   const validation = linkedAccount
-    ? { valid: true, exactName: linkedAccount.tvUsername }
+    ? { valid: true, exactName: linkedAccount.tvUsername, reason: undefined }
     : await new TradingViewService().validateUsername(tvUsername)
 
   if (!validation.valid) {
+    const validationUnavailable = validation.reason === 'unavailable'
     await writeClaimAudit({
       userId: input.userId,
       indicatorId: input.indicatorId,
       tvUsername,
       action: 'claim',
       result: 'failure',
-      errorCode: 'invalid_username',
+      errorCode: validationUnavailable ? 'username_validation_unavailable' : 'invalid_username',
     })
     return {
       ok: false,
       indicatorId: input.indicatorId,
       tvUsername,
-      message: `TradingView-Benutzername "${tvUsername}" wurde nicht gefunden.`,
+      message: validationUnavailable
+        ? 'TradingView konnte den Benutzernamen gerade nicht prüfen. Bitte versuche es in einem Moment erneut.'
+        : `TradingView-Benutzername "${tvUsername}" wurde nicht gefunden.`,
     }
   }
 
@@ -1293,10 +1299,13 @@ async function upsertTradingViewWorkerHeartbeat(input: {
   })
 }
 
-async function markDueClaimsAsNeedsSession(message: string, code: string) {
+async function markDueClaimsAsNeedsSession(message: string, code: string, claimId?: string) {
   const now = new Date()
   await prisma.indicatorClaim.updateMany({
-    where: { status: { in: ['pending', 'processing', 'failed'] } },
+    where: {
+      ...(claimId ? { id: claimId } : {}),
+      status: { in: ['pending', 'processing', 'failed'] },
+    },
     data: {
       status: 'needs_session',
       errorMessage:
@@ -1327,7 +1336,11 @@ export async function processTradingViewClaimQueue({
   const cappedLimit = Math.max(1, Math.min(limit, 100))
 
   if (!tv.isConfigured) {
-    await markDueClaimsAsNeedsSession('TradingView cookie is not configured.', 'not_configured')
+    await markDueClaimsAsNeedsSession(
+      'TradingView cookie is not configured.',
+      'not_configured',
+      claimId
+    )
     await upsertTradingViewWorkerHeartbeat({
       workerId,
       status: 'blocked',
@@ -1345,7 +1358,11 @@ export async function processTradingViewClaimQueue({
 
   const session = await tv.testSession()
   if (!session.success) {
-    await markDueClaimsAsNeedsSession(session.message, session.code ?? 'login_required')
+    await markDueClaimsAsNeedsSession(
+      session.message,
+      session.code ?? 'login_required',
+      claimId
+    )
     await upsertTradingViewWorkerHeartbeat({
       workerId,
       status: 'blocked',
@@ -1364,7 +1381,11 @@ export async function processTradingViewClaimQueue({
 
   const staleProcessingCutoff = new Date(Date.now() - 15 * 60 * 1000)
   await prisma.indicatorClaim.updateMany({
-    where: { status: 'processing', lastAttemptAt: { lt: staleProcessingCutoff } },
+    where: {
+      ...(claimId ? { id: claimId } : {}),
+      status: 'processing',
+      lastAttemptAt: { lt: staleProcessingCutoff },
+    },
     data: {
       status: 'pending',
       errorMessage: 'Der vorherige TradingView-Prozess war stale. Die Freigabe ist zurück in der Queue.',

--- a/lib/indicators/tradingview.ts
+++ b/lib/indicators/tradingview.ts
@@ -1,4 +1,5 @@
 const TV_BASE = 'https://www.tradingview.com'
+const USERNAME_VALIDATION_TIMEOUT_MS = 8_000
 const DEFAULT_BROWSER_USER_AGENT =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36'
 
@@ -67,6 +68,7 @@ function extractHintUsernames(payload: unknown): string[] {
 export type TradingViewValidationResult = {
   valid: boolean
   exactName: string
+  reason?: 'invalid' | 'unavailable'
 }
 
 export type TradingViewAccessResult = {
@@ -95,25 +97,30 @@ export class TradingViewService {
   async validateUsername(username: string): Promise<TradingViewValidationResult> {
     const normalizedUsername = normalizeUsernameInput(username)
     if (normalizedUsername.length < 2) {
-      return { valid: false, exactName: '' }
+      return { valid: false, exactName: '', reason: 'invalid' }
     }
 
     try {
       const res = await fetch(
         `${TV_BASE}/username_hint/?s=${encodeURIComponent(normalizedUsername)}`,
-        { headers: { 'User-Agent': process.env.TRADINGVIEW_USER_AGENT?.trim() || DEFAULT_BROWSER_USER_AGENT } }
+        {
+          headers: {
+            'User-Agent': process.env.TRADINGVIEW_USER_AGENT?.trim() || DEFAULT_BROWSER_USER_AGENT,
+          },
+          signal: AbortSignal.timeout(USERNAME_VALIDATION_TIMEOUT_MS),
+        }
       )
 
-      if (!res.ok) return { valid: false, exactName: '' }
+      if (!res.ok) return { valid: false, exactName: '', reason: 'unavailable' }
 
       const data: unknown = await res.json()
       const exact = extractHintUsernames(data).find(
         (match) => match.toLowerCase() === normalizedUsername.toLowerCase()
       )
 
-      return { valid: Boolean(exact), exactName: exact ?? '' }
+      return { valid: Boolean(exact), exactName: exact ?? '', reason: exact ? undefined : 'invalid' }
     } catch {
-      return { valid: false, exactName: '' }
+      return { valid: false, exactName: '', reason: 'unavailable' }
     }
   }
 


### PR DESCRIPTION
## What changed

- keeps the desktop hero particle animation intact while removing an unused mousemove/layout-read rerender path
- replaces stale March 2026 countdown and enrollment copy across the landing page and dashboard
- serializes page-editor saves, surfaces save failures, validates titles, and improves keyboard/focus behavior
- narrows instant TradingView claim processing to the requested claim and distinguishes validation outages from invalid usernames
- reduces eager loading for testimonials/final CTA and removes the global navbar Suspense placeholder
- fixes duplicate form IDs and removes duplicated carousel controls from the accessibility tree

## Why

The first performance audit found unnecessary client work, stale user-facing state, avoidable accessibility friction, and reliability gaps in editor saves and instant indicator claims.

## Validation

- `npm run lint`
- `npx tsc --noEmit --pretty false --incremental false`
- production `npm run build` against the `main` dependency lockfile
- desktop and mobile browser QA for hero animation, enrollment state, overflow, countdowns, duplicate IDs, and console errors

## Scope

This PR is intentionally isolated from the parallel Security, dependency, middleware, database, and infrastructure changes in the original dirty worktree.
