### PR TITLE
Improve mobile hero and mentorship checkout funnel

### DIFF
--- a/app/(dashboard)/dashboard/dashboard-conversion-client.tsx
+++ b/app/(dashboard)/dashboard/dashboard-conversion-client.tsx
@@ -1,15 +1,16 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { ArrowClockwise } from '@phosphor-icons/react/ArrowClockwise'
 import { BookOpen } from '@phosphor-icons/react/BookOpen'
 import { CalendarCheck } from '@phosphor-icons/react/CalendarCheck'
 import { CheckCircle as CircleCheckBig } from '@phosphor-icons/react/CheckCircle'
 import { LockIcon } from '@phosphor-icons/react/Lock'
-import { Ticket } from '@phosphor-icons/react/Ticket'
-import { trackConversion } from '@/components/analytics/tracking'
+import { SpinnerGap } from '@phosphor-icons/react/SpinnerGap'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 
 const CheckoutButton = dynamic(
@@ -17,17 +18,27 @@ const CheckoutButton = dynamic(
   {
     ssr: false,
     loading: () => (
-      <Button disabled className="w-full text-lg py-6" size="lg">
-        Checkout wird geladen...
+      <Button disabled className="w-full py-6 text-base sm:text-lg" size="lg">
+        Checkout wird geladen…
       </Button>
     ),
   }
 )
 
+const benefits = [
+  '2 Live-Sessions pro Woche (Di + Do)',
+  'Tagesausblick am Dienstag und Donnerstag',
+  'Wöchentlicher Marktausblick mit Draw on Liquidity',
+  '3–4 vollständige Trading-Modelle mit Trading Plan',
+  'Fokussierte Community für Austausch und Feedback',
+  'Alle Aufzeichnungen während deiner Mitgliedschaft',
+]
+
 type DashboardConversionClientProps = {
   firstName: string | null
   viewFlags: {
     showCheckoutSuccess: boolean
+    showCheckoutCanceled: boolean
     showCoursesPaywall: boolean
     showMentorshipNotStarted: boolean
   }
@@ -37,193 +48,285 @@ export default function DashboardConversionClient({
   firstName,
   viewFlags,
 }: DashboardConversionClientProps) {
-  const { showCheckoutSuccess, showCoursesPaywall, showMentorshipNotStarted } = viewFlags
+  const {
+    showCheckoutSuccess,
+    showCheckoutCanceled,
+    showCoursesPaywall,
+    showMentorshipNotStarted,
+  } = viewFlags
+  const router = useRouter()
   const [termsAccepted, setTermsAccepted] = useState(false)
-  const hasTrackedPurchase = useRef(false)
+  const [confirmationChecks, setConfirmationChecks] = useState(0)
+  const [showCanceledNotice, setShowCanceledNotice] = useState(showCheckoutCanceled)
 
   useEffect(() => {
-    if (showCheckoutSuccess && !hasTrackedPurchase.current) {
-      hasTrackedPurchase.current = true
-      trackConversion.purchase(150)
-    }
-  }, [showCheckoutSuccess])
+    if (!showCheckoutSuccess || confirmationChecks >= 2) return
 
-  const clearPaywallParam = useCallback(() => {
+    const timeoutId = window.setTimeout(() => {
+      setConfirmationChecks((current) => current + 1)
+      router.refresh()
+    }, 2500)
+
+    return () => window.clearTimeout(timeoutId)
+  }, [confirmationChecks, router, showCheckoutSuccess])
+
+  const clearPaywallParam = () => {
     if (window.history.replaceState) {
       window.history.replaceState({}, '', '/dashboard')
     }
-  }, [])
+  }
+
+  const dismissCanceledNotice = () => {
+    setShowCanceledNotice(false)
+    if (window.history.replaceState) {
+      window.history.replaceState({}, '', '/dashboard')
+    }
+  }
+
+  if (showCheckoutSuccess) {
+    return (
+      <div className="min-h-screen bg-gray-50 px-4 py-10 sm:py-16">
+        <Card className="mx-auto max-w-xl border-blue-200 shadow-sm" role="status" aria-live="polite">
+          <CardContent className="p-6 text-center sm:p-8">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-700">
+              <SpinnerGap aria-hidden="true" className="h-6 w-6 animate-spin motion-reduce:animate-none" />
+            </div>
+            <h1 className="mt-5 text-balance text-2xl font-bold text-gray-900 sm:text-3xl">
+              Deine Zahlung wird bestätigt
+            </h1>
+            <p className="mt-3 text-pretty leading-relaxed text-gray-600">
+              Stripe hat dich zurückgeleitet. Die Freischaltung kann einen kurzen Moment dauern;
+              wir prüfen deinen Zugang automatisch.
+            </p>
+            <p className="mt-5 rounded-lg border border-blue-200 bg-blue-50 p-3 text-sm text-blue-900">
+              Bitte starte jetzt keinen zweiten Checkout – dein Zahlungsstatus wird bereits verarbeitet.
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-6 touch-manipulation"
+              onClick={() => router.refresh()}
+            >
+              <ArrowClockwise aria-hidden="true" className="h-4 w-4" />
+              Status erneut prüfen
+            </Button>
+            {confirmationChecks >= 2 ? (
+              <p className="mt-4 text-sm text-gray-500">
+                Die Bestätigung dauert länger als üblich. Lade die Seite in wenigen Minuten erneut.
+              </p>
+            ) : (
+              <p className="mt-4 text-sm text-gray-500">Automatische Prüfung läuft…</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-12">
-      <div className="container mx-auto px-4 max-w-4xl animate-in fade-in duration-500">
-        {showCoursesPaywall && (
-          <div className="mb-8 animate-in fade-in slide-in-from-bottom-3 duration-500">
-            <Card className="border-amber-200 bg-amber-50 shadow-sm">
-              <CardContent className="p-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                <div className="flex items-start gap-3">
-                  <div className="mt-0.5 flex h-10 w-10 items-center justify-center rounded-lg bg-amber-100 text-amber-700">
-                    <LockIcon className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <p className="font-semibold text-amber-900">Zugriff auf den Kursbereich gesperrt</p>
-                    <p className="text-sm text-amber-900/80 mt-1">
-                      Um die Kurse zu öffnen, brauchst du ein aktives Mentorship-Abo.
-                    </p>
-                  </div>
+    <div className="min-h-screen bg-gray-50 py-6 sm:py-12">
+      <div className="container mx-auto max-w-4xl px-4">
+        {showCanceledNotice ? (
+          <Card className="mb-6 border-blue-200 bg-blue-50 shadow-sm" role="status">
+            <CardContent className="flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-100 text-blue-700">
+                  <LockIcon aria-hidden="true" className="h-5 w-5" />
                 </div>
-                <div className="flex flex-col sm:flex-row gap-2">
-                  <Button variant="outline" asChild className="w-full sm:w-auto">
-                    <a href="#checkout-cta">Jetzt freischalten</a>
-                  </Button>
-                  <Button variant="ghost" className="w-full sm:w-auto" onClick={clearPaywallParam}>
-                    Später
-                  </Button>
+                <div>
+                  <p className="font-semibold text-blue-950">Checkout abgebrochen</p>
+                  <p className="mt-1 text-sm text-blue-900/80">
+                    Dieser Checkout wurde nicht abgeschlossen. Du kannst deine Konditionen in Ruhe prüfen.
+                  </p>
                 </div>
-              </CardContent>
-            </Card>
-          </div>
-        )}
-
-        {showMentorshipNotStarted && (
-          <div className="mb-8 animate-in fade-in slide-in-from-bottom-3 duration-500">
-            <Card className="border-blue-200 bg-blue-50 shadow-sm">
-              <CardContent className="p-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-                <div className="flex items-start gap-3">
-                  <div className="mt-0.5 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-blue-700">
-                    <CalendarCheck className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <p className="font-semibold text-blue-900">
-                      {MENTORSHIP_IS_UPCOMING ? 'Mentorship startet bald' : 'Mentorship-Zugang wird vorbereitet'}
-                    </p>
-                    <p className="text-sm text-blue-900/80 mt-1">
-                      {MENTORSHIP_IS_UPCOMING
-                        ? `Du hast bereits ein aktives Abo! Der Mentorship-Bereich öffnet am ${MENTORSHIP_CONFIG.startDateFormatted}.`
-                        : 'Du hast bereits ein aktives Abo. Lade die Seite neu, falls der Mentorship-Bereich noch nicht freigeschaltet ist.'}
-                    </p>
-                  </div>
-                </div>
-                <div className="flex flex-col sm:flex-row gap-2">
-                  <Button variant="ghost" className="w-full sm:w-auto" onClick={clearPaywallParam}>
-                    Verstanden
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        )}
-
-        <div className="text-center mb-12">
-          <div className="animate-in fade-in slide-in-from-bottom-3 duration-500">
-            <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-              Willkommen, {firstName || 'zukünftiger Trader'}!
-            </h1>
-            <p className="text-lg text-gray-600">
-              Noch wenige Plätze verfügbar - sichere dir deinen Zugang zur M26.
-            </p>
-          </div>
-        </div>
-
-        <Card className="mb-8 shadow-sm border-2">
-          <CardContent className="p-8">
-            <div className="bg-amber-50 border-2 border-amber-400 rounded-lg p-5 mb-8">
-              <div className="text-center">
-                <p className="text-2xl font-bold text-amber-900 flex items-center justify-center gap-2">
-                  <Ticket className="w-6 h-6 shrink-0" />
-                  Nur noch wenige der 100 Plätze verfügbar
-                </p>
-                <p className="text-sm text-amber-700 mt-2">
-                  Die Vergabe erfolgt nach dem Prinzip: Wer zuerst kommt, mahlt zuerst.
-                </p>
               </div>
+              <Button type="button" variant="ghost" className="touch-manipulation" onClick={dismissCanceledNotice}>
+                Verstanden
+              </Button>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {showCoursesPaywall ? (
+          <Card className="mb-6 border-amber-200 bg-amber-50 shadow-sm">
+            <CardContent className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-100 text-amber-700">
+                  <LockIcon aria-hidden="true" className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="font-semibold text-amber-900">Zugriff auf den Kursbereich gesperrt</p>
+                  <p className="mt-1 text-sm text-amber-900/80">
+                    Um die Kurse zu öffnen, brauchst du ein aktives Mentorship-Abo.
+                  </p>
+                </div>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Button variant="outline" asChild className="w-full touch-manipulation sm:w-auto">
+                  <a href="#checkout-cta">Zum Checkout</a>
+                </Button>
+                <Button variant="ghost" className="w-full touch-manipulation sm:w-auto" onClick={clearPaywallParam}>
+                  Später
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {showMentorshipNotStarted ? (
+          <Card className="mb-6 border-blue-200 bg-blue-50 shadow-sm">
+            <CardContent className="flex flex-col gap-4 p-5 md:flex-row md:items-center md:justify-between">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-100 text-blue-700">
+                  <CalendarCheck aria-hidden="true" className="h-5 w-5" />
+                </div>
+                <div>
+                  <p className="font-semibold text-blue-900">
+                    {MENTORSHIP_IS_UPCOMING ? 'Mentorship startet bald' : 'Mentorship-Zugang wird vorbereitet'}
+                  </p>
+                  <p className="mt-1 text-sm text-blue-900/80">
+                    {MENTORSHIP_IS_UPCOMING
+                      ? `Du hast bereits ein aktives Abo. Der Mentorship-Bereich öffnet am ${MENTORSHIP_CONFIG.startDateFormatted}.`
+                      : 'Du hast bereits ein aktives Abo. Lade die Seite neu, falls der Mentorship-Bereich noch nicht freigeschaltet ist.'}
+                  </p>
+                </div>
+              </div>
+              <Button variant="ghost" className="touch-manipulation" onClick={clearPaywallParam}>
+                Verstanden
+              </Button>
+            </CardContent>
+          </Card>
+        ) : null}
+
+        <header className="mb-8 text-center sm:mb-10">
+          <p className="text-sm font-medium text-blue-700">Willkommen{firstName ? `, ${firstName}` : ''}</p>
+          <h1 className="mt-2 text-balance text-3xl font-bold text-gray-900 sm:text-4xl">
+            Dein Einstieg in die {MENTORSHIP_CONFIG.programName}
+          </h1>
+          <p className="mx-auto mt-3 max-w-2xl text-pretty text-gray-600 sm:text-lg">
+            Prüfe die Konditionen und buche im nächsten Schritt sicher über Stripe.
+          </p>
+        </header>
+
+        <Card className="mb-8 border-2 shadow-sm">
+          <CardContent className="p-5 sm:p-8">
+            <div className="rounded-xl border border-blue-200 bg-blue-50 p-4 sm:p-5">
+              <p className="font-semibold text-blue-950">So geht es weiter</p>
+              <ol className="mt-4 grid gap-4 sm:grid-cols-3" aria-label="Buchungsfortschritt">
+                <li className="flex items-center gap-3 sm:block">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-emerald-600 text-sm font-semibold text-white sm:mb-2">
+                    ✓
+                  </span>
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">Konto erstellt</p>
+                    <p className="text-xs text-gray-600">Schritt 1 erledigt</p>
+                  </div>
+                </li>
+                <li className="flex items-center gap-3 sm:block">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-700 text-sm font-semibold text-white sm:mb-2">
+                    2
+                  </span>
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">Konditionen bestätigen</p>
+                    <p className="text-xs text-gray-600">Jetzt hier</p>
+                  </div>
+                </li>
+                <li className="flex items-center gap-3 sm:block">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-sm font-semibold text-gray-700 ring-1 ring-gray-300 sm:mb-2">
+                    3
+                  </span>
+                  <div>
+                    <p className="text-sm font-semibold text-gray-900">Sicher bezahlen</p>
+                    <p className="text-xs text-gray-600">Bei Stripe abschließen</p>
+                  </div>
+                </li>
+              </ol>
             </div>
 
-            <div className="text-center mb-8">
+            <div className="my-7 text-center">
               <div className="flex items-baseline justify-center">
-                <span className="text-5xl font-bold text-gray-900">€150</span>
-                <span className="text-xl text-gray-500 ml-2">/Monat</span>
+                <span className="text-4xl font-bold text-gray-900 sm:text-5xl">{MENTORSHIP_CONFIG.priceFormatted}</span>
+                <span className="ml-2 text-lg text-gray-500 sm:text-xl">/Monat</span>
               </div>
-              <p className="text-sm text-gray-600 mt-2 font-medium">
-                inkl. gesetzl. MwSt. · monatlich kündbar
+              <p className="mt-2 text-sm font-medium text-gray-600">
+                inkl. gesetzl. MwSt. · monatlich kündbar mit 1 Tag Frist zum Monatsende
               </p>
-              <p className="text-sm text-green-600 mt-1 font-medium">
+              <p className="mt-1 text-sm font-medium text-emerald-700">
                 {MENTORSHIP_IS_UPCOMING
                   ? `Keine Zahlung bis ${MENTORSHIP_CONFIG.startDateFormatted}`
-                  : MENTORSHIP_CONFIG.paymentNote}
+                  : 'Zugang nach erfolgreicher Zahlung und Freischaltung'}
               </p>
             </div>
 
-            <div className="grid sm:grid-cols-2 gap-4 mb-8">
-              {[
-                '2 Live-Sessions pro Woche (Di + Do)',
-                'Tagesausblick am Dienstag und Donnerstag',
-                'Wöchentlicher Marktausblick mit Draw on Liquidity',
-                '3-4 vollständige Trading-Modelle mit Trading Plan',
-                'Exklusive Community (max. 100 Trader)',
-                'Monatlich kündbar',
-              ].map((benefit, index) => (
-                <div
-                  key={benefit}
-                  className="flex items-start gap-3 bg-gray-50 p-3 rounded-lg border border-gray-200 animate-in fade-in slide-in-from-bottom-2 duration-500"
-                  style={{ animationDelay: `${index * 75}ms` }}
-                >
-                  <div className="flex-shrink-0 mt-0.5">
-                    <CircleCheckBig className="h-5 w-5 text-green-400" />
-                  </div>
-                  <span className="text-gray-700 text-sm">{benefit}</span>
-                </div>
-              ))}
-            </div>
-
-            <div id="checkout-cta" className="space-y-6">
-              <div className="flex items-start gap-3">
+            <div id="checkout-cta" className="space-y-5 scroll-mt-6">
+              <div className="flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
                 <input
                   type="checkbox"
                   id="terms"
                   checked={termsAccepted}
-                  onChange={(e) => setTermsAccepted(e.target.checked)}
-                  className="mt-1 h-5 w-5 text-blue-600 rounded border-gray-300 focus:ring-blue-500"
+                  onChange={(event) => setTermsAccepted(event.target.checked)}
+                  className="mt-0.5 h-5 w-5 shrink-0 cursor-pointer rounded border-gray-300 text-blue-600 focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
                 />
-                <label htmlFor="terms" className="text-sm text-gray-700 leading-relaxed">
-                  Ich akzeptiere die{' '}
-                  <a href="/AGB" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline hover:text-blue-800">
+                <div className="text-sm leading-relaxed text-gray-700">
+                  <label htmlFor="terms" className="cursor-pointer">
+                    Ich akzeptiere die folgenden Bedingungen:
+                  </label>{' '}
+                  <a href="/AGB" target="_blank" rel="noopener noreferrer" className="text-blue-700 underline underline-offset-2 hover:text-blue-900">
                     AGB
                   </a>
-                  , habe die{' '}
-                  <a href="/Widerruf" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline hover:text-blue-800">
+                  ,{' '}
+                  <a href="/Widerruf" target="_blank" rel="noopener noreferrer" className="text-blue-700 underline underline-offset-2 hover:text-blue-900">
                     Widerrufsbelehrung
-                  </a>{' '}
-                  zur Kenntnis genommen und stimme der{' '}
-                  <a href="/datenschutz" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline hover:text-blue-800">
+                  </a>{' '}und{' '}
+                  <a href="/datenschutz" target="_blank" rel="noopener noreferrer" className="text-blue-700 underline underline-offset-2 hover:text-blue-900">
                     Datenschutzerklärung
-                  </a>{' '}
-                  zu.
-                </label>
+                  </a>.
+                </div>
               </div>
 
-              <CheckoutButton disabled={!termsAccepted} />
+              <CheckoutButton
+                disabled={!termsAccepted}
+                disabledReason="Bitte akzeptiere zuerst AGB, Widerruf und Datenschutz."
+                label={`Weiter zu Stripe – ${MENTORSHIP_CONFIG.priceFormatted}/Monat`}
+              />
 
-              <div className="flex items-center justify-center gap-2 text-sm text-gray-500">
-                <LockIcon className="h-4 w-4" />
-                <span>Sichere Zahlung über Stripe</span>
+              <div className="text-center text-sm text-gray-500">
+                <p className="flex items-center justify-center gap-2">
+                  <LockIcon aria-hidden="true" className="h-4 w-4" />
+                  Sichere Zahlung über Stripe
+                </p>
+                <p className="mt-1">
+                  Dein Platz ist erst nach erfolgreichem Abschluss bei Stripe gebucht.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-8 border-t border-gray-200 pt-7">
+              <h2 className="text-lg font-semibold text-gray-900">Das ist enthalten</h2>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                {benefits.map((benefit) => (
+                  <div key={benefit} className="flex items-start gap-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+                    <CircleCheckBig aria-hidden="true" className="mt-0.5 h-5 w-5 shrink-0 text-emerald-600" />
+                    <span className="text-sm text-gray-700">{benefit}</span>
+                  </div>
+                ))}
               </div>
             </div>
           </CardContent>
         </Card>
 
-        <div className="grid md:grid-cols-2 gap-6">
+        <div className="grid gap-6 md:grid-cols-2">
           <Card className="shadow-sm">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <BookOpen className="h-5 w-5 text-blue-600" />
+                <BookOpen aria-hidden="true" className="h-5 w-5 text-blue-600" />
                 Interaktives Live-Lernen
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-600 text-sm">
+              <p className="text-sm text-gray-600">
                 Lerne durch Live-Sessions mit Echtzeit-Marktanalysen, direktem Feedback
-                und interaktiven Frage & Antwort Runden. Perfekt für Anfänger und erfahrene Trader.
+                und interaktiven Frage-und-Antwort-Runden.
               </p>
             </CardContent>
           </Card>
@@ -231,14 +334,14 @@ export default function DashboardConversionClient({
           <Card className="shadow-sm">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <LockIcon className="h-5 w-5 text-blue-600" />
-                Risikofreie Entscheidung
+                <LockIcon aria-hidden="true" className="h-5 w-5 text-blue-600" />
+                Flexible Entscheidung
               </CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-gray-600 text-sm">
-                Faire Bedingungen - kündige jederzeit, wenn du nicht vollständig zufrieden bist.
-                Erhalte dauerhaften Zugang nach Abschluss der Mentorship (12 Monate).
+              <p className="text-sm text-gray-600">
+                Zahle monatlich und kündige mit 1 Tag Frist zum Monatsende, wenn das Mentorship nicht mehr zu dir passt.
+                Bis zum Ende der bezahlten Periode bleibt dein Zugang erhalten.
               </p>
             </CardContent>
           </Card>

--- a/app/(dashboard)/dashboard/dashboard-member-client.tsx
+++ b/app/(dashboard)/dashboard/dashboard-member-client.tsx
@@ -60,6 +60,7 @@ type SubscriptionDetails = {
   isPending: boolean
   isCanceled: boolean
   cancelAt: string | null
+  currentPeriodEnd: string | null
 }
 
 type DashboardMemberClientProps = {
@@ -88,20 +89,28 @@ export default function DashboardMemberClient({
   const mentorshipStatus = initialData.mentorshipStatus
   const mentorshipStartDate = formatMentorshipDate(initialData.mentorshipStatus.startDate)
   const subscriptionStartDate = formatMentorshipDate(initialData.subscriptionDetails.startDate)
+  const subscriptionEndDate = initialData.subscriptionDetails.currentPeriodEnd
+    ? formatMentorshipDate(initialData.subscriptionDetails.currentPeriodEnd)
+    : null
   const subscriptionIsPending =
     initialData.subscriptionDetails.isPending ||
     initialData.subscriptionDetails.status === 'incomplete'
   const hasMentorshipAccess =
     initialData.hasSubscription && mentorshipStatus?.accessible
-  const [showSuccessModal, setShowSuccessModal] = useState(() => showCheckoutSuccess)
+  const [showSuccessModal, setShowSuccessModal] = useState(
+    () => showCheckoutSuccess && initialData.hasSubscription
+  )
   const hasTrackedPurchase = useRef(false)
 
   useEffect(() => {
-    if (showCheckoutSuccess && !hasTrackedPurchase.current) {
+    if (showCheckoutSuccess && initialData.hasSubscription && !hasTrackedPurchase.current) {
       hasTrackedPurchase.current = true
-      trackConversion.purchase(150)
+      trackConversion.purchase(MENTORSHIP_CONFIG.price)
+      if (window.history.replaceState) {
+        window.history.replaceState({}, '', '/dashboard')
+      }
     }
-  }, [showCheckoutSuccess])
+  }, [initialData.hasSubscription, showCheckoutSuccess])
 
   const handleCloseModal = useCallback(() => {
     setShowSuccessModal(false)
@@ -122,6 +131,7 @@ export default function DashboardMemberClient({
       {showSuccessModal && (
         <SubscriptionSuccessModal
           isOpen={true}
+          hasMentorshipAccess={hasMentorshipAccess}
           onClose={handleCloseModal}
         />
       )}
@@ -217,7 +227,9 @@ export default function DashboardMemberClient({
               <div className="text-sm text-gray-600">
                 {initialData.subscriptionDetails.isCanceled ? (
                   <p className="text-red-600">
-                    Dein Abonnement wurde gekündigt. Erneuere es, um deinen Zugang zur Mentorship zu sichern.
+                    {initialData.hasSubscription
+                      ? `Dein Abonnement ist gekündigt. Dein Zugang bleibt ${subscriptionEndDate ? `bis zum ${subscriptionEndDate}` : 'bis zum Ende der bezahlten Periode'} aktiv.`
+                      : 'Dein Abonnement ist gekündigt und aktuell nicht mehr aktiv.'}
                   </p>
                 ) : subscriptionIsPending ? (
                   <p className="text-amber-700">

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -31,6 +31,7 @@ export default async function DashboardPage({
   }
 
   const showCheckoutSuccess = resolvedParams?.success === 'true'
+  const showCheckoutCanceled = resolvedParams?.canceled === 'true'
   const showCoursesPaywall = resolvedParams?.paywall === 'courses'
   const showMentorshipNotStarted = resolvedParams?.message === 'mentorship-not-started'
   const checkForRecentCheckout = showCheckoutSuccess
@@ -104,6 +105,7 @@ export default async function DashboardPage({
         firstName={firstName}
         viewFlags={{
           showCheckoutSuccess,
+          showCheckoutCanceled,
           showCoursesPaywall,
           showMentorshipNotStarted,
         }}
@@ -118,7 +120,7 @@ export default async function DashboardPage({
         subscriptionDetails: initialData.subscriptionDetails,
       }}
       viewFlags={{
-        showCheckoutSuccess,
+        showCheckoutSuccess: showCheckoutSuccess && initialData.hasSubscription,
         showCoursesPaywall,
       }}
     />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import { AnalyticsScriptsLoader } from '@/components/analytics/analytics-scripts
 import { JsonLd } from '@/components/seo/json-ld'
 import { Suspense, lazy } from 'react'
 import { CURRENT_BUNNY_THUMBNAIL_HOST } from '@/lib/bunny-thumbnail'
+import { MENTORSHIP_CONFIG } from '@/lib/config'
 
 // Agentation nur in Development laden (ist devDependency)
 const Agentation = process.env.NODE_ENV === 'development' 
@@ -41,7 +42,7 @@ export const metadata: Metadata = {
     default: 'PAT Mentorship 2026 | Trading nach ICT Konzepten lernen — Live & auf Deutsch',
     template: '%s | PAT Mentorship',
   },
-  description: 'Lerne Trading nach ICT Smart Money Konzepten im Live-Mentoring. 2-3 Sessions pro Woche, auf Deutsch. 130+ erfolgreiche Absolventen. Monatlich kündbar.',
+  description: `Lerne Trading nach ICT Smart Money Konzepten im Live-Mentoring. ${MENTORSHIP_CONFIG.sessionsPerWeek} Sessions pro Woche, auf Deutsch. 130+ erfolgreiche Absolventen. Monatlich kündbar.`,
   keywords: ['ICT Trading', 'Smart Money Concept', 'Price Action Trading', 'Trading Mentoring Deutsch', 'Live Trading lernen', 'ICT auf Deutsch', 'Trading Ausbildung'],
   authors: [{ name: 'Petar', url: 'https://www.price-action-trader.de' }],
   creator: 'Price Action Trader',
@@ -55,7 +56,7 @@ export const metadata: Metadata = {
     url: 'https://www.price-action-trader.de',
     siteName: 'Price Action Trader',
     title: 'PAT Mentorship 2026 | ICT Trading Live & auf Deutsch',
-    description: 'Lerne Trading nach ICT Smart Money Konzepten im Live-Mentoring. 2-3 Sessions/Woche, deutschsprachig, monatlich kündbar.',
+    description: `Lerne Trading nach ICT Smart Money Konzepten im Live-Mentoring. ${MENTORSHIP_CONFIG.sessionsPerWeek} Sessions/Woche, deutschsprachig, monatlich kündbar.`,
     images: [
       {
         url: '/images/pat-banner.jpeg',

--- a/components/analytics/tracking.ts
+++ b/components/analytics/tracking.ts
@@ -15,17 +15,19 @@ export function trackEvent(eventName: string, eventParams?: Record<string, unkno
  * Spezifische Conversion-Events für Google Ads.
  */
 export const trackConversion = {
-  ctaClick: () => {
+  ctaClick: (source = 'hero_cta') => {
     trackEvent('cta_click', {
       event_category: 'engagement',
-      event_label: 'hero_cta',
+      event_label: source,
+      cta_source: source,
     })
   },
 
-  signInStart: () => {
+  signInStart: (source = 'unknown_cta') => {
     trackEvent('sign_in_start', {
       event_category: 'engagement',
       event_label: 'begin_sign_in',
+      cta_source: source,
     })
   },
 

--- a/components/dashboard/subscription-success-modal.tsx
+++ b/components/dashboard/subscription-success-modal.tsx
@@ -2,6 +2,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import Link from 'next/link'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { CheckCircle } from '@phosphor-icons/react/CheckCircle'
@@ -10,10 +11,11 @@ import confetti from 'canvas-confetti'
 
 interface SuccessModalProps {
   isOpen: boolean
+  hasMentorshipAccess: boolean
   onClose: () => void
 }
 
-export function SubscriptionSuccessModal({ isOpen, onClose }: SuccessModalProps) {
+export function SubscriptionSuccessModal({ isOpen, hasMentorshipAccess, onClose }: SuccessModalProps) {
   useEffect(() => {
     if (!isOpen) return
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
@@ -70,13 +72,23 @@ export function SubscriptionSuccessModal({ isOpen, onClose }: SuccessModalProps)
         </DialogHeader>
         <div className="text-center space-y-4">
           <p className="text-gray-600">
-            {MENTORSHIP_IS_UPCOMING
-              ? `Dein Platz ist gesichert. Die Mentorship startet am ${MENTORSHIP_CONFIG.startDateFormatted}.`
-              : 'Dein Platz ist gesichert. Du kannst jetzt direkt mit der Mentorship starten.'}
+            {hasMentorshipAccess
+              ? 'Deine Buchung ist bestätigt. Du kannst jetzt direkt mit der Mentorship starten.'
+              : MENTORSHIP_IS_UPCOMING
+                ? `Deine Buchung ist bestätigt. Die Mentorship startet am ${MENTORSHIP_CONFIG.startDateFormatted}.`
+                : 'Deine Buchung ist bestätigt. Dein Mentorship-Zugang wird gerade freigeschaltet.'}
           </p>
-          <Button onClick={onClose} className="w-full">
-            Zum Dashboard
-          </Button>
+          {hasMentorshipAccess ? (
+            <Button asChild className="w-full">
+              <Link href="/mentorship" onClick={onClose}>
+                Mentorship öffnen
+              </Link>
+            </Button>
+          ) : (
+            <Button onClick={onClose} className="w-full">
+              Zum Dashboard
+            </Button>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/components/indicators/indicator-usage-guide.tsx
+++ b/components/indicators/indicator-usage-guide.tsx
@@ -55,7 +55,7 @@ const markdownComponents: Components = {
   td: ({ children }) => <td className="border-t px-3 py-2 text-muted-foreground">{children}</td>,
   hr: () => <hr className="border-border" />,
   img: ({ src, alt }) => {
-    if (!src) return null
+    if (typeof src !== 'string' || !src) return null
 
     return (
       <a href={src} target="_blank" rel="noreferrer" className="block">

--- a/components/sections/cta-section-1.tsx
+++ b/components/sections/cta-section-1.tsx
@@ -1,39 +1,12 @@
 // src/components/sections/cta-section.tsx
 'use client'
 
-import { SignInButton, useUser } from '@clerk/nextjs'
-import { useRouter } from 'next/navigation'
 import { Card } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
 import { VortexBackground } from "@/components/ui/vortex-wrapper"
-import { trackConversion } from '@/components/analytics/tracking'
+import { MentorshipEntryCta } from '@/components/sections/mentorship-entry-cta'
 import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 
 export default function CTASection() {
-  const { isSignedIn } = useUser()
-  const router = useRouter()
-  
-  const handleScrollToDetails = () => {
-    const target = document.getElementById('why-different')
-    if (target) {
-      target.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    } else {
-      window.location.hash = 'why-different'
-    }
-  }
-
-  const handleClick = () => {
-    trackConversion.ctaClick()
-    if (isSignedIn) {
-      router.push('/dashboard')
-    }
-  }
-  
-  const handleSignInClick = () => {
-    trackConversion.ctaClick()
-    trackConversion.signInStart()
-  }
-
   return (
     <section className="py-16 sm:py-24 px-0 sm:px-4 bg-slate-950">
       <div className="container mx-auto max-w-6xl">
@@ -49,36 +22,22 @@ export default function CTASection() {
                 <p className="text-base sm:text-lg opacity-90 mb-6">
                   {MENTORSHIP_IS_UPCOMING
                     ? 'Trete jetzt der Warteliste bei und sichere dir als einer der Ersten deinen Platz im Mentorship Programm 2026.'
-                    : 'Steige in die laufende Mentorship 2026 ein, solange noch ein Platz verfügbar ist.'}
+                    : 'Steige in die laufende Mentorship 2026 ein und prüfe alle Konditionen vor der Buchung.'}
                 </p>
-                {isSignedIn ? (
-                  <Button 
-                    size="lg" 
-                    className="w-full sm:w-auto bg-white text-slate-900 hover:bg-white/90"
-                    onClick={handleClick}
-                  >
-                    Sichere dir deinen Platz
-                  </Button>
-                ) : (
-                  <div className="flex flex-col gap-3">
-                    <SignInButton mode="modal" forceRedirectUrl="/dashboard">
-                      <Button 
-                        size="lg" 
-                        className="w-full sm:w-auto bg-white text-slate-900 hover:bg-white/90"
-                        onClick={handleSignInClick}
-                      >
-                        Sichere dir deinen Platz
-                      </Button>
-                    </SignInButton>
-                  </div>
-                )}
+                <MentorshipEntryCta
+                  source="section_cta"
+                  className="w-full bg-white text-slate-900 hover:bg-white/90 sm:w-auto"
+                />
+                <p className="mt-3 text-xs text-slate-300 sm:text-sm">
+                  Kostenlos anmelden → Konditionen prüfen → sicher über Stripe buchen
+                </p>
               </div>
               
               <div className="space-y-3 sm:space-y-6">
                 <div className="bg-white/5 backdrop-blur-sm rounded-lg p-3 sm:p-4 border border-white/10">
-                  <p className="text-sm sm:text-base font-medium">🎯 Limitiert auf {MENTORSHIP_CONFIG.maxSpots} Plätze</p>
+                  <p className="text-sm sm:text-base font-medium">🎯 Fokussierte Community</p>
                   <p className="text-xs sm:text-sm opacity-90">
-                    Wir halten das Programm exklusiv, um qualitativ hochwertiges Mentoring zu gewährleisten.
+                    Austausch, Rückfragen und direktes Feedback begleiten deinen Lernprozess.
                   </p>
                 </div>
                 <div className="bg-white/5 backdrop-blur-sm rounded-lg p-3 sm:p-4 border border-white/10">
@@ -86,7 +45,7 @@ export default function CTASection() {
                     🚀 {MENTORSHIP_IS_UPCOMING ? `Start im ${MENTORSHIP_CONFIG.startMonthYear}` : MENTORSHIP_CONFIG.enrollmentLabel}
                   </p>
                   <p className="text-xs sm:text-sm opacity-90">
-                    Die Vergabe der Plätze erfolgt nach dem Prinzip: Wer zuerst kommt, mahlt zuerst.
+                    Der Einstieg in den laufenden Jahrgang ist aktuell möglich.
                   </p>
                 </div>
                 <div className="bg-white/5 backdrop-blur-sm rounded-lg p-3 sm:p-4 border border-white/10">
@@ -95,8 +54,8 @@ export default function CTASection() {
                   </p>
                   <p className="text-xs sm:text-sm opacity-90">
                     {MENTORSHIP_IS_UPCOMING
-                      ? `Dein Zahlungsmittel wird erst beim Start der Mentorship mit ${MENTORSHIP_CONFIG.price}€/Monat (inkl. MwSt.) belastet. Du kannst jederzeit kündigen.`
-                      : `${MENTORSHIP_CONFIG.price}€/Monat (inkl. MwSt.). Du kannst jederzeit kündigen.`}
+                      ? `Dein Zahlungsmittel wird erst beim Start der Mentorship mit ${MENTORSHIP_CONFIG.price}€/Monat (inkl. MwSt.) belastet. Kündbar mit 1 Tag Frist zum Monatsende.`
+                      : `${MENTORSHIP_CONFIG.price}€/Monat (inkl. MwSt.). Kündbar mit 1 Tag Frist zum Monatsende.`}
                   </p>
                 </div>
               </div>

--- a/components/sections/faq.tsx
+++ b/components/sections/faq.tsx
@@ -8,12 +8,12 @@ const faqs = [
       : 'Kann ich noch in die Mentorship 2026 einsteigen?',
     answer: MENTORSHIP_IS_UPCOMING
       ? `Der Start am ${MENTORSHIP_CONFIG.startDateFormatted} ermöglicht es mir, alle Teilnehmer einzusammeln und sicherzustellen, dass alle gemeinsam beginnen, um von Tag eins an eine starke Community aufzubauen. Dies gibt dir auch die Zeit, deinen Platz zu sichern und dich auf das Programm vorzubereiten.`
-      : 'Ja, solange noch ein Platz verfügbar ist. Nach der Freischaltung erhältst du direkten Zugang zum laufenden Programm, zu den bisherigen Aufzeichnungen und zur Community.',
+      : 'Ja. Nach der Freischaltung erhältst du direkten Zugang zum laufenden Programm, zu den bisherigen Aufzeichnungen und zur Community.',
   },
   {
     id: "item-2",
     question: "Wie funktioniert das monatliche Abonnement?",
-    answer: `Das Programm kostet ${MENTORSHIP_CONFIG.price}€ pro Monat (inkl. MwSt.) und du kannst jederzeit kündigen, wenn du nicht zufrieden bist. Dieses flexible Modell gewährleistet hochwertige Betreuung und ermöglicht es dir gleichzeitig, den Wert des Programms monatlich zu evaluieren.`,
+    answer: `Das Programm kostet ${MENTORSHIP_CONFIG.price}€ pro Monat (inkl. MwSt.) und ist mit 1 Tag Frist zum Monatsende kündbar. Dieses flexible Modell ermöglicht es dir, den Wert des Programms monatlich zu evaluieren.`,
   },
   {
     id: "item-3",
@@ -28,7 +28,7 @@ const faqs = [
   {
     id: "item-5",
     question: "Was passiert, wenn ich mein Abonnement kündige?",
-    answer: "Du behältst den Zugang bis zum Ende deiner bezahlten Periode. Falls du später wieder einsteigen möchtest, beachte, dass die Plätze begrenzt sind und möglicherweise nicht mehr verfügbar sind. Der Abschluss des gesamten Jahres gewährt dir dauerhaften Zugriff auf alle Materialien.",
+    answer: "Du behältst den Zugang bis zum Ende deiner bezahlten Periode. Danach endet der Zugriff auf den Mentorship-Bereich, die Community und die Aufzeichnungen.",
   },
   {
     id: "item-6",
@@ -58,7 +58,7 @@ const faqs = [
   {
     id: "item-11",
     question: "Gibt es eine Rückerstattungspolitik?",
-    answer: "Da wir mit einem monatlichen Abonnement-Modell arbeiten, gibt es keine langfristige Bindung. Du kannst jederzeit kündigen, wenn du das Gefühl hast, dass das Programm nicht deinen Erwartungen entspricht.",
+    answer: "Da wir mit einem monatlichen Abonnement-Modell arbeiten, gibt es keine langfristige Bindung. Du kannst mit 1 Tag Frist zum Monatsende kündigen, wenn das Programm nicht deinen Erwartungen entspricht.",
   },
   {
     id: "item-12",

--- a/components/sections/final-cta.tsx
+++ b/components/sections/final-cta.tsx
@@ -2,17 +2,13 @@
 "use client"
 import dynamic from "next/dynamic"
 import { type CSSProperties, type ReactNode, useEffect, useRef, useState } from "react"
-import { Button } from "@/components/ui/button"
-import { ArrowRight } from "@phosphor-icons/react/ArrowRight"
 import { Clock } from "@phosphor-icons/react/Clock"
 import { Trophy } from "@phosphor-icons/react/Trophy"
 import { Users } from "@phosphor-icons/react/Users"
 import { Countdown } from "@/components/ui/countdown"
-import { useUser, SignInButton } from '@clerk/nextjs'
-import { useRouter } from 'next/navigation'
-import { trackConversion } from '@/components/analytics/tracking'
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
+import { MentorshipEntryCta } from '@/components/sections/mentorship-entry-cta'
 
 const Vortex = dynamic(
     () => import("@/components/ui/vortex").then((mod) => mod.Vortex),
@@ -54,8 +50,6 @@ function FinalCtaInfoCard({
 }
 
 export default function FinalCTA() {
-    const { isSignedIn } = useUser()
-    const router = useRouter()
     const isMobile = useMediaQuery("(max-width: 768px)")
     const sectionRef = useRef<HTMLElement>(null)
     const [isInView, setIsInView] = useState(false)
@@ -77,25 +71,6 @@ export default function FinalCTA() {
             baseRadius: 0.5,
             rangeRadius: 1.5,
         }
-
-    // Handle click for signed-in users
-    const handleJoinClick = () => {
-        trackConversion.ctaClick()
-        router.push('/dashboard')
-    }
-    
-    // Handle click for non-signed-in users
-    const handleSignInClick = () => {
-        trackConversion.ctaClick()
-        trackConversion.signInStart()
-    }
-
-    const buttonContent = (
-        <>
-            <span>Prüfen ob Plätze frei sind</span>
-            <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
-        </>
-    )
 
     useEffect(() => {
         if (!sectionRef.current) return
@@ -121,35 +96,6 @@ export default function FinalCTA() {
         media.addEventListener('change', updatePreference)
         return () => media.removeEventListener('change', updatePreference)
     }, [])
-
-    const ctaButton = isSignedIn ? (
-        <Button
-            onClick={handleJoinClick}
-            size="lg"
-            className="bg-white text-slate-900 hover:bg-white/90 text-sm sm:text-lg px-6 sm:px-8 py-4 sm:py-6 h-auto group"
-        >
-            {buttonContent}
-        </Button>
-    ) : (
-        <SignInButton mode="modal" forceRedirectUrl="/dashboard">
-            <Button
-                size="lg"
-                className="bg-white text-slate-900 hover:bg-white/90 text-sm sm:text-lg px-6 sm:px-8 py-4 sm:py-6 h-auto group"
-                onClick={handleSignInClick}
-            >
-                {buttonContent}
-            </Button>
-        </SignInButton>
-    )
-    
-    const handleScrollToDetails = () => {
-        const target = document.getElementById('why-different')
-        if (target) {
-            target.scrollIntoView({ behavior: 'smooth', block: 'start' })
-        } else {
-            window.location.hash = 'why-different'
-        }
-    }
 
     return (
         <section ref={sectionRef} className="relative py-12 sm:py-24 overflow-hidden">
@@ -179,15 +125,13 @@ export default function FinalCTA() {
                                 <span className="text-xs sm:text-sm font-medium text-blue-400">Jetzt starten</span>
                             </div>
                         </div>
-                        <h2 className="text-2xl sm:text-4xl md:text-5xl font-bold text-white mb-4 sm:mb-6">
-                            Deine Trading-Reise <br />
-                            <span className="text-blue-400">
-                                {MENTORSHIP_IS_UPCOMING ? `Beginnt im ${MENTORSHIP_CONFIG.startMonthYear}` : 'Beginnt jetzt'}
-                            </span>
+                        <h2 className="text-balance text-2xl font-bold text-white sm:text-4xl md:text-5xl">
+                            Bereit, ICT <span className="text-blue-400">live anzuwenden?</span>
                         </h2>
-                        <p className="text-sm sm:text-xl text-gray-300 max-w-2xl mx-auto">
-                            Werde einer von {MENTORSHIP_CONFIG.maxSpots} ambitionierten Tradern und erlebe ein transformatives Jahr 
-                            mit Live-Marktanalysen, Echtzeit-Trading und messbarem Wachstum.
+                        <p className="mx-auto mt-4 max-w-2xl text-pretty text-sm text-gray-300 sm:mt-6 sm:text-xl">
+                            {MENTORSHIP_IS_UPCOMING
+                                ? `Melde dich für den Start im ${MENTORSHIP_CONFIG.startMonthYear} an und sichere dir Zugang zu Live-Sessions, Aufzeichnungen und Community.`
+                                : 'Steig in die laufende Mentorship ein und erhalte Zugang zu Live-Sessions, Aufzeichnungen und Community.'}
                         </p>
                     </div>
                     <div className="mt-6 sm:mt-8 flex justify-center">
@@ -210,20 +154,22 @@ export default function FinalCTA() {
                     {[
                         {
                             icon: <Users className="h-8 w-8 text-blue-400 mb-4" />,
-                            title: "Begrenzte Plätze",
-                            description: `Nur ${MENTORSHIP_CONFIG.maxSpots} Trader werden aufgenommen, um eine qualitativ hochwertige Betreuung zu gewährleisten`,
+                            title: "Fokussierte Community",
+                            description: "Austausch, Rückfragen und direktes Feedback begleiten deinen Lernprozess.",
                             glowColor: "#60A5FA" // blue-400
                         },
                         {
                             icon: <Clock className="h-8 w-8 text-purple-400 mb-4" />,
-                            title: "Frühzeitig Sichern",
-                            description: "Die Vergabe der Mentorship-Plätze erfolgt nach dem Prinzip: Wer zuerst kommt, mahlt zuerst.",
+                            title: "Flexibler Einstieg",
+                            description: MENTORSHIP_IS_UPCOMING
+                                ? `Start im ${MENTORSHIP_CONFIG.startMonthYear}; kündbar mit 1 Tag Frist zum Monatsende.`
+                                : "Der laufende Jahrgang ist offen und mit 1 Tag Frist zum Monatsende kündbar.",
                             glowColor: "#A78BFA" // purple-400
                         },
                         {
                             icon: <Trophy className="h-8 w-8 text-green-400 mb-4" />,
-                            title: "Lebenslanger Zugang",
-                            description: "Schließe das Jahr ab und erhalte permanenten Zugriff auf alle Materialien und Aufzeichnungen",
+                            title: "Aufzeichnungen inklusive",
+                            description: "Greife während deiner Mitgliedschaft auf Materialien und bisherige Sessions zu.",
                             glowColor: "#4ADE80" // green-400
                         }
                     ].map((card) => (
@@ -238,15 +184,20 @@ export default function FinalCTA() {
                 </div>
 
                 <div className="text-center mt-6 sm:mt-8 md:mt-0 motion-safe:animate-[final-cta-pop_500ms_ease-out_200ms_both]">
-                    {ctaButton}
+                    <MentorshipEntryCta
+                        source="final_cta"
+                        className="h-auto bg-white px-6 py-4 text-sm text-slate-900 hover:bg-white/90 sm:px-8 sm:py-6 sm:text-lg"
+                    />
                     
                     <p className="mt-4 sm:mt-6 text-xs sm:text-base text-gray-400">
-                        {MENTORSHIP_IS_UPCOMING ? 'Keine Zahlung bis zum Programmstart.' : MENTORSHIP_CONFIG.paymentNote}
+                        Kostenlos anmelden → Konditionen prüfen → sicher über Stripe buchen
                     </p>
 
                     <div className="mt-6 sm:mt-12 inline-flex items-center gap-1.5 sm:gap-2 pl-1.5 sm:pl-2 pr-3 sm:pr-4 py-1 rounded-full bg-white/10 ring-1 ring-white/20">
                         <div className="bg-amber-500/20 text-amber-400 rounded-full px-2 py-0.5 text-xs sm:text-sm">⚡</div>
-                        <span className="text-xs sm:text-sm font-medium text-amber-300">Nur die ersten {MENTORSHIP_CONFIG.maxSpots} Anmeldungen werden akzeptiert</span>
+                        <span className="text-xs sm:text-sm font-medium text-amber-300">
+                            Transparente Konditionen · monatlich kündbar
+                        </span>
                     </div>
                 </div>
             </div>

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -3,19 +3,15 @@
 import { useState, useEffect, useRef } from 'react'
 import dynamic from 'next/dynamic'
 import { Button } from "@/components/ui/button"
-import { ArrowRight } from "@phosphor-icons/react/ArrowRight"
 import { ChartLine as LineChart } from "@phosphor-icons/react/ChartLine"
 import { Medal as Award } from "@phosphor-icons/react/Medal"
 import { SealCheck as BadgeCheck } from "@phosphor-icons/react/SealCheck"
 import { Star } from "@phosphor-icons/react/Star"
 import { Users } from "@phosphor-icons/react/Users"
-import Link from "next/link"
 import { Countdown } from "@/components/ui/countdown"
 import Image from "next/image"
 import { useMediaQuery } from "@/hooks/use-media-query"
-import { SignInButton, useUser } from '@clerk/nextjs'
-import { useRouter } from 'next/navigation'
-import { trackConversion } from '@/components/analytics/tracking'
+import { MentorshipEntryCta } from '@/components/sections/mentorship-entry-cta'
 import { HeroPill } from '@/components/ui/hero-pill'
 import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 import { getWhopReviewStats } from '@/lib/whop-review-stats'
@@ -35,13 +31,9 @@ const ParticleTextReveal = dynamic(
 
 export default function Hero() {
   const containerRef = useRef<HTMLDivElement>(null)
-  const navigationTimeoutRef = useRef<number | null>(null)
-  const isMobile = useMediaQuery("(max-width: 768px)")
-  const [isNavigating, setIsNavigating] = useState(false)
+  const isMobile = useMediaQuery("(max-width: 1023px)")
   const [isInView, setIsInView] = useState(false)
   const [showAmbientBackground, setShowAmbientBackground] = useState(false)
-  const { isSignedIn } = useUser()
-  const router = useRouter()
   const [whopStats, setWhopStats] = useState<{ count: number; average: number } | null>(null)
 
   useEffect(() => {
@@ -122,14 +114,6 @@ export default function Hero() {
     }
   }, [])
 
-  useEffect(() => {
-    return () => {
-      if (navigationTimeoutRef.current != null) {
-        window.clearTimeout(navigationTimeoutRef.current)
-      }
-    }
-  }, [])
-
   const whopCount = whopStats?.count ?? 48
   const whopAvg = whopStats?.average ?? 5
   const whopAvgRounded = Math.round(whopAvg * 10) / 10
@@ -138,49 +122,18 @@ export default function Hero() {
     ','
   )
 
-  const handleGetStarted = () => {
-    // Track CTA Click für Conversion-Optimierung
-    trackConversion.ctaClick()
-    
-    if (isSignedIn) {
-      setIsNavigating(true)
-      router.push('/dashboard')
-      if (navigationTimeoutRef.current != null) {
-        window.clearTimeout(navigationTimeoutRef.current)
-      }
-      navigationTimeoutRef.current = window.setTimeout(() => {
-        setIsNavigating(false)
-        navigationTimeoutRef.current = null
-      }, 500)
-    }
-  }
-  
-  const handleSignInClick = () => {
-    // Track wenn nicht-eingeloggter User auf CTA klickt
-    trackConversion.ctaClick()
-    trackConversion.signInStart()
-  }
-  
-  const handleScrollToDetails = () => {
-    const target = document.getElementById('why-different')
-    if (target) {
-      target.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    } else {
-      window.location.hash = 'why-different'
-    }
-  }
-
   const handleScrollToMentorTarget = (targetName: string) => {
+    const behavior = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'
     const viewport = isMobile ? 'mobile' : 'desktop'
     const selector = `[data-mentor-target="${targetName}"][data-mentor-viewport="${viewport}"]`
     const target = document.querySelector(selector)
     if (target) {
-      target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      target.scrollIntoView({ behavior, block: 'start' })
       return
     }
     const fallback = document.querySelector(`[data-mentor-target="${targetName}"]`)
     if (fallback) {
-      fallback.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      fallback.scrollIntoView({ behavior, block: 'start' })
     }
   }
 
@@ -199,9 +152,42 @@ export default function Hero() {
 
       {/* Content */}
       <div className="container mx-auto px-4 relative z-10 h-full">
-            <div className="grid lg:grid-cols-2 gap-8 lg:gap-12 items-start lg:items-center mt-0 lg:mt-8">
+            <div className="grid lg:grid-cols-2 gap-7 lg:gap-12 items-start lg:items-center mt-0 lg:mt-8">
             {/* Left Column - Text Content */}
-              <div className="space-y-8 order-2 lg:order-1">
+              <div className="space-y-5 order-1 lg:space-y-8">
+
+              <div className="flex flex-wrap items-center gap-2 lg:hidden">
+                <HeroPill
+                  href="https://whop.com/price-action-trader-mentorship-24-d9/pat-mentorship-2025/"
+                  isExternal
+                  variant="amber"
+                  size="sm"
+                  announcement={
+                    <span className="flex items-center gap-1">
+                      <Image
+                        src="/images/whop-logo.png"
+                        alt="Whop"
+                        width={16}
+                        height={16}
+                        className="h-4 w-4"
+                      />
+                      <Star aria-hidden="true" weight="fill" className="h-3 w-3 fill-amber-500 text-amber-500" />
+                    </span>
+                  }
+                  label={`${whopAvgText}/5 · ${whopCount} Reviews`}
+                />
+                <HeroPill
+                  variant="blue"
+                  size="sm"
+                  className="whitespace-normal py-2 text-center leading-snug"
+                  announcement="🚀"
+                  label={
+                    MENTORSHIP_IS_UPCOMING
+                      ? `Start ${MENTORSHIP_CONFIG.startDateFormatted}`
+                      : 'Einstieg möglich'
+                  }
+                />
+              </div>
               
               <div className="hidden lg:flex flex-wrap items-center gap-3">
                 <HeroPill
@@ -220,7 +206,7 @@ export default function Hero() {
                       />
                       <span className="flex items-center gap-0.5">
                         {[1, 2, 3, 4, 5].map((star) => (
-                          <Star key={star} weight="fill" className="h-3 w-3 fill-amber-500 text-amber-500" />
+                          <Star aria-hidden="true" key={star} weight="fill" className="h-3 w-3 fill-amber-500 text-amber-500" />
                         ))}
                       </span>
                     </span>
@@ -234,14 +220,19 @@ export default function Hero() {
                   announcement="🚀"
                   label={
                     MENTORSHIP_IS_UPCOMING
-                      ? `Limitiert auf ${MENTORSHIP_CONFIG.maxSpots} Plätze • Start am ${MENTORSHIP_CONFIG.startDateFormatted}`
+                      ? `Start am ${MENTORSHIP_CONFIG.startDateFormatted}`
                       : MENTORSHIP_CONFIG.enrollmentLabel
                   }
                 />
               </div>
+              <h1 className="text-balance text-[2rem] font-bold leading-[1.08] text-gray-900 lg:hidden">
+                ICT verstehen.{' '}
+                <span className="text-blue-600">Im Live-Mentoring anwenden.</span>
+              </h1>
+
               <h1 className="hidden lg:block text-4xl md:text-5xl lg:text-6xl font-bold tracking-tight text-gray-900 lg:leading-[1.1]">
                 Dein{" "}
-                {isInView ? (
+                {!isMobile && isInView ? (
                   <ParticleTextReveal text="Live-Mentoring:" fontSize={58} />
                 ) : (
                   <span className="text-blue-600">
@@ -253,60 +244,50 @@ export default function Hero() {
               
               <p className="hidden lg:block text-lg md:text-xl text-gray-600 leading-relaxed max-w-xl">
                 Ich baue dein Verständnis Schritt für Schritt auf: Theorie, danach Live-Tape-Reading und später echtes Live-Trading.
-                Du zahlst monatlich und kannst jederzeit kündigen, wenn der Mehrwert nicht passt.
+                Du zahlst monatlich und kannst zum Monatsende kündigen, wenn der Mehrwert nicht passt.
+              </p>
+
+              <p className="text-pretty text-base leading-relaxed text-gray-600 lg:hidden">
+                {MENTORSHIP_CONFIG.sessionsPerWeek} Live-Sessions pro Woche, klare Trading-Modelle und direktes Feedback – für{' '}
+                {MENTORSHIP_CONFIG.priceFormatted} im Monat, monatlich kündbar.
               </p>
               
-              <div className="flex flex-col sm:flex-row sm:justify-center lg:justify-start gap-4 pt-2 w-full">
-                <div className="w-full sm:w-auto">
-                  {isSignedIn ? (
-                    <Button size="lg" variant="outline" className="w-full" onClick={handleScrollToDetails}>
-                      Details erkunden
-                    </Button>
-                  ) : (
-                    <Button size="lg" variant="outline" className="w-full" onClick={handleScrollToDetails}>
-                      Details erkunden
-                    </Button>
-                  )}
-                </div>
-                
-                <div className="w-full sm:w-auto">
-                  {isSignedIn ? (
+              <div className="pt-1">
+                <div className="flex w-full flex-col gap-3 sm:flex-row sm:justify-center lg:justify-start">
+                  <div className="w-full sm:w-auto">
+                    <MentorshipEntryCta
+                      source="hero_cta"
+                      className="w-full"
+                    />
+                  </div>
+                  <div className="w-full sm:w-auto">
                     <Button
+                      asChild
                       size="lg"
-                      onClick={handleGetStarted}
-                      disabled={isNavigating}
-                      className="w-full flex items-center gap-2 justify-center"
+                      variant="outline"
+                      className="w-full touch-manipulation"
                     >
-                      Prüfen ob Plätze frei sind
-                      <ArrowRight className="h-4 w-4" />
+                      <a href="#why-different">Programm &amp; Ablauf ansehen</a>
                     </Button>
-                  ) : (
-                    <SignInButton mode="modal" forceRedirectUrl="/dashboard">
-                      <Button 
-                        size="lg" 
-                        className="w-full flex items-center gap-2 justify-center"
-                        onClick={handleSignInClick}
-                      >
-                        Prüfen ob Plätze frei sind
-                        <ArrowRight className="h-4 w-4" />
-                      </Button>
-                    </SignInButton>
-                  )}
+                  </div>
                 </div>
+                <p className="mt-3 text-center text-xs leading-relaxed text-gray-500 sm:text-sm lg:text-left">
+                  Kostenlos anmelden → Konditionen prüfen → sicher über Stripe buchen
+                </p>
               </div>
 
-              <div className="flex flex-wrap justify-center gap-3 pt-4 lg:pt-3 text-center lg:justify-start lg:text-left">
-                <div className="min-w-[110px] flex-1 sm:flex-initial">
+              <div className="grid grid-cols-3 gap-2 pt-2 text-center lg:flex lg:flex-wrap lg:justify-start lg:gap-6 lg:pt-3 lg:text-left">
+                <div>
                   <p className="text-xl lg:text-3xl font-bold text-gray-900">{MENTORSHIP_CONFIG.priceFormatted}</p>
                   <p className="text-xs sm:text-sm text-gray-600">/Monat (inkl. MwSt.)</p>
                 </div>
-                <div className="min-w-[110px] flex-1 sm:flex-initial">
-                  <p className="text-xl lg:text-3xl font-bold text-gray-900">2-3x</p>
+                <div>
+                  <p className="text-xl lg:text-3xl font-bold text-gray-900">{MENTORSHIP_CONFIG.sessionsPerWeek}×</p>
                   <p className="text-xs sm:text-sm text-gray-600">Live Calls / Woche</p>
                 </div>
-                <div className="min-w-[110px] flex-1 sm:flex-initial">
-                  <p className="text-xl lg:text-3xl font-bold text-gray-900">100</p>
-                  <p className="text-xs sm:text-sm text-gray-600">Limitierte Plätze</p>
+                <div>
+                  <p className="text-xl lg:text-3xl font-bold text-gray-900">Flexibel</p>
+                  <p className="text-xs sm:text-sm text-gray-600">monatlich kündbar</p>
                 </div>
               </div>
 
@@ -322,42 +303,9 @@ export default function Hero() {
             </div>
 
             {/* Right Column - Visual Element */}
-            <div className="relative flex items-center justify-center lg:-mt-8 order-1 lg:order-2">
+            <div className="relative flex items-center justify-center order-2 lg:-mt-8">
               <div className="relative w-full max-w-lg mx-auto">
-                <div className="relative overflow-hidden rounded-2xl shadow-xl ring-1 ring-gray-200/60 bg-white aspect-[2/3] sm:aspect-[4/5]">
-                  <div className="absolute inset-0 bg-gradient-to-t from-gray-900/75 via-gray-900/35 to-transparent" />
-                  <div className="absolute top-4 left-4 right-4 lg:hidden z-10">
-                    <HeroPill
-                      href="https://whop.com/price-action-trader-mentorship-24-d9/pat-mentorship-2025/"
-                      isExternal
-                      variant="amber"
-                      size="sm"
-                      announcement={
-                        <span className="flex items-center gap-1.5">
-                          <Image
-                            src="/images/whop-logo.png"
-                            alt="Whop"
-                            width={16}
-                            height={16}
-                            className="h-4 w-4"
-                          />
-                          <span className="flex items-center gap-0.5">
-                            {[1, 2, 3, 4, 5].map((star) => (
-                              <Star key={`mobile-top-star-${star}`} weight="fill" className="h-3 w-3 fill-amber-500 text-amber-500" />
-                            ))}
-                          </span>
-                        </span>
-                      }
-                      label={`${whopCount} Bewertungen`}
-                    />
-                    <h1 className="mt-2 text-[26px] sm:text-3xl font-bold tracking-tight text-gray-900 leading-snug drop-shadow-sm">
-                      Dein{" "}
-                      <span className="text-blue-600">
-                        Live-Mentoring:
-                      </span>
-                      {" "}ICT verstehen, lernen und anwenden
-                    </h1>
-                  </div>
+                <div className="relative aspect-[4/5] overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-gray-200/60">
                   <Image
                     src="/images/mentor-image-2.png"
                     alt="Mentorship Live Call"
@@ -366,44 +314,45 @@ export default function Hero() {
                     sizes="(max-width: 1024px) 90vw, 520px"
                     priority
                   />
-                  <div className="absolute bottom-4 left-4 right-4 grid grid-cols-2 gap-1.5 sm:gap-2">
+                  <div className="absolute inset-0 z-[1] bg-gradient-to-t from-gray-900/75 via-gray-900/20 to-transparent" />
+                  <div className="absolute bottom-4 left-4 right-4 z-10 grid grid-cols-2 gap-2">
                     <button
                       type="button"
                       onClick={() => handleScrollToMentorTarget('experience')}
-                      className="flex items-center gap-1.5 sm:gap-2 rounded-md bg-white px-2 py-2 sm:px-3 sm:py-2.5 text-[10px] sm:text-xs font-semibold text-gray-900 shadow-md hover:bg-gray-50 transition"
+                      className="flex min-h-11 touch-manipulation items-center gap-2 rounded-md bg-white px-2 py-2 text-left text-xs font-semibold text-gray-900 shadow-md transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 sm:px-3 sm:py-2.5"
                     >
                       <div className="h-5 w-5 sm:h-6 sm:w-6 rounded-md bg-purple-500/15 text-purple-700 flex items-center justify-center shrink-0">
-                        <Award className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                        <Award aria-hidden="true" className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
                       </div>
                       2 Jahre Coaching
                     </button>
                     <button
                       type="button"
                       onClick={() => handleScrollToMentorTarget('mentees')}
-                      className="flex items-center gap-1.5 sm:gap-2 rounded-md bg-white px-2 py-2 sm:px-3 sm:py-2.5 text-[10px] sm:text-xs font-semibold text-gray-900 shadow-md hover:bg-gray-50 transition"
+                      className="flex min-h-11 touch-manipulation items-center gap-2 rounded-md bg-white px-2 py-2 text-left text-xs font-semibold text-gray-900 shadow-md transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 sm:px-3 sm:py-2.5"
                     >
                       <div className="h-5 w-5 sm:h-6 sm:w-6 rounded-md bg-blue-500/15 text-blue-700 flex items-center justify-center shrink-0">
-                        <Users className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                        <Users aria-hidden="true" className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
                       </div>
                       130+ Absolventen
                     </button>
                     <button
                       type="button"
                       onClick={() => handleScrollToMentorTarget('performance')}
-                      className="flex items-center gap-1.5 sm:gap-2 rounded-md bg-white px-2 py-2 sm:px-3 sm:py-2.5 text-[10px] sm:text-xs font-semibold text-gray-900 shadow-md hover:bg-gray-50 transition"
+                      className="flex min-h-11 touch-manipulation items-center gap-2 rounded-md bg-white px-2 py-2 text-left text-xs font-semibold text-gray-900 shadow-md transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 sm:px-3 sm:py-2.5"
                     >
                       <div className="h-5 w-5 sm:h-6 sm:w-6 rounded-md bg-emerald-500/15 text-emerald-700 flex items-center justify-center shrink-0">
-                        <LineChart className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                        <LineChart aria-hidden="true" className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
                       </div>
                       Performance sichtbar
                     </button>
                     <button
                       type="button"
                       onClick={() => handleScrollToMentorTarget('payout')}
-                      className="flex items-center gap-1.5 sm:gap-2 rounded-md bg-white px-2 py-2 sm:px-3 sm:py-2.5 text-[10px] sm:text-xs font-semibold text-gray-900 shadow-md hover:bg-gray-50 transition"
+                      className="flex min-h-11 touch-manipulation items-center gap-2 rounded-md bg-white px-2 py-2 text-left text-xs font-semibold text-gray-900 shadow-md transition-colors hover:bg-gray-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 sm:px-3 sm:py-2.5"
                     >
                       <div className="h-5 w-5 sm:h-6 sm:w-6 rounded-md bg-amber-500/15 text-amber-700 flex items-center justify-center shrink-0">
-                        <BadgeCheck className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                        <BadgeCheck aria-hidden="true" className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
                       </div>
                       Payout‑Nachweis
                     </button>
@@ -415,11 +364,11 @@ export default function Hero() {
                   <HeroPill
                     variant="blue"
                     size="sm"
-                    className="w-full justify-center"
+                    className="w-full justify-center whitespace-normal py-2 text-center leading-snug"
                     announcement="🚀"
                     label={
                       MENTORSHIP_IS_UPCOMING
-                        ? `Limitiert auf ${MENTORSHIP_CONFIG.maxSpots} Plätze • Start am ${MENTORSHIP_CONFIG.startDateFormatted}`
+                        ? `Start am ${MENTORSHIP_CONFIG.startDateFormatted}`
                         : MENTORSHIP_CONFIG.enrollmentLabel
                     }
                   />
@@ -459,7 +408,7 @@ export default function Hero() {
                       </div>
                       <div className="mt-2 flex items-center gap-1 text-amber-500">
                         {Array.from({ length: 5 }).map((_, i) => (
-                          <Star key={i} weight="fill" className="h-4 w-4 fill-current" />
+                          <Star aria-hidden="true" key={i} weight="fill" className="h-4 w-4 fill-current" />
                         ))}
                       </div>
                     </div>
@@ -468,12 +417,12 @@ export default function Hero() {
                   <div className="hidden lg:block rounded-xl border bg-white p-4 shadow-sm h-full">
                     <div className="flex items-center gap-3">
                       <div className="h-7 w-7 rounded-lg bg-emerald-500/15 text-emerald-700 flex items-center justify-center">
-                        <BadgeCheck className="h-4 w-4" />
+                        <BadgeCheck aria-hidden="true" className="h-4 w-4" />
                       </div>
-                      <p className="text-sm font-semibold text-gray-900">Langfristiger Zugang</p>
+                      <p className="text-sm font-semibold text-gray-900">Aufzeichnungen inklusive</p>
                     </div>
                     <p className="text-xs text-gray-600 mt-1">
-                      Bleib 12 Monate dabei & erhalte dauerhaft Zugriff auf alle Materialien
+                      Greife während deiner Mitgliedschaft auf Materialien und Aufzeichnungen zu
                     </p>
                   </div>
                 </div>

--- a/components/sections/hormozi-landing-cta-button.tsx
+++ b/components/sections/hormozi-landing-cta-button.tsx
@@ -1,9 +1,4 @@
-'use client'
-
-import { SignInButton, useUser } from '@clerk/nextjs'
-import { useRouter } from 'next/navigation'
-import { Button } from '@/components/ui/button'
-import { trackConversion } from '@/components/analytics/tracking'
+import { MentorshipEntryCta } from '@/components/sections/mentorship-entry-cta'
 
 type HormoziLandingCtaButtonProps = {
   buttonText: string
@@ -11,32 +6,11 @@ type HormoziLandingCtaButtonProps = {
 }
 
 export function HormoziLandingCtaButton({ buttonText, className }: HormoziLandingCtaButtonProps) {
-  const { isSignedIn } = useUser()
-  const router = useRouter()
-
-  const handleJoinClick = () => {
-    trackConversion.ctaClick()
-    router.push('/dashboard')
-  }
-
-  const handleSignInClick = () => {
-    trackConversion.ctaClick()
-    trackConversion.signInStart()
-  }
-
-  if (isSignedIn) {
-    return (
-      <Button size="lg" className={className} onClick={handleJoinClick}>
-        {buttonText}
-      </Button>
-    )
-  }
-
   return (
-    <SignInButton mode="modal" forceRedirectUrl="/dashboard">
-      <Button size="lg" className={className} onClick={handleSignInClick}>
-        {buttonText}
-      </Button>
-    </SignInButton>
+    <MentorshipEntryCta
+      source="lp_v1_cta"
+      label={buttonText}
+      className={className}
+    />
   )
 }

--- a/components/sections/hormozi-landing.tsx
+++ b/components/sections/hormozi-landing.tsx
@@ -17,7 +17,7 @@ export default function HormoziLanding() {
             <span className="rounded-sm bg-yellow-200 px-1 text-blue-700">profitabel.</span>
           </h1>
           <p className="text-pretty text-base font-medium leading-relaxed text-slate-700 sm:text-lg">
-            Die meisten Kurse enden bei Theorie. Ich fange dort an – wir gehen 2–3x pro Woche live in den Markt. So
+            Die meisten Kurse enden bei Theorie. Ich fange dort an – wir gehen {MENTORSHIP_CONFIG.sessionsPerWeek}× pro Woche live in den Markt. So
             lernst du, was wirklich funktioniert.
           </p>
 
@@ -36,12 +36,11 @@ export default function HormoziLanding() {
 
           <div className="mt-4 flex w-full flex-col items-center gap-3">
             <HormoziLandingCtaButton
-              buttonText="Prüfen, ob Plätze frei sind"
+              buttonText="Einstieg starten"
               className="h-14 w-full px-8 text-base sm:w-auto sm:text-lg"
             />
             <p className="text-xs text-slate-500">
-              {MENTORSHIP_CONFIG.price}€/Monat · monatlich kündbar ·{" "}
-              <span className="rounded-sm bg-yellow-200 px-1 text-blue-700">max. {MENTORSHIP_CONFIG.maxSpots} Plätze</span>
+              Kostenlos anmelden → Konditionen prüfen → sicher über Stripe buchen
             </p>
           </div>
         </div>
@@ -103,7 +102,7 @@ export default function HormoziLanding() {
               {
                   title: 'Ist das für Anfänger?',
                   copy:
-                    'Ja. Die Mentorship ist für Anfänger gebaut. Wenn du keinen Mehrwert merkst, dann kannst du monatlich kündigen.',
+                    'Ja. Die Mentorship ist für Anfänger gebaut. Wenn du keinen Mehrwert merkst, kannst du mit 1 Tag Frist zum Monatsende kündigen.',
                 },
               ].map((item) => (
                 <div key={item.title} className="rounded-xl border border-slate-200 bg-white p-5 text-left sm:p-6 lg:p-7">
@@ -123,7 +122,7 @@ export default function HormoziLanding() {
               {[
               {
                   title: 'Live Trading + Prognosen',
-                  copy: '2–3 Sessions pro Woche am echten Chart. Tages- und Wochenausblicke.',
+                  copy: `${MENTORSHIP_CONFIG.sessionsPerWeek} Sessions pro Woche am echten Chart. Tages- und Wochenausblicke.`,
                 },
                 {
                   title: 'Aufzeichnungen',
@@ -166,7 +165,7 @@ export default function HormoziLanding() {
             <span className="rounded-sm bg-yellow-200 px-1 text-blue-700">ICT Live‑Coaching</span> + klare Regeln
           </h2>
           <p className="text-pretty mt-4 text-sm text-slate-600 sm:text-base">
-            Du bekommst 2–3 Live‑Sessions pro Woche. Du kommst rein, indem du dich anmeldest.
+            Du bekommst {MENTORSHIP_CONFIG.sessionsPerWeek} Live‑Sessions pro Woche. Du kommst rein, indem du dich anmeldest.
           </p>
           <div className="mt-6 flex justify-center">
             {MENTORSHIP_IS_UPCOMING ? (
@@ -186,12 +185,11 @@ export default function HormoziLanding() {
           </div>
           <div className="mt-7 space-y-3">
             <HormoziLandingCtaButton
-              buttonText="Prüfe, ob noch Plätze frei sind"
+              buttonText="Einstieg starten"
               className="h-14 w-full bg-blue-600 px-8 text-base text-white hover:bg-blue-700 sm:h-16 sm:w-auto sm:text-lg"
             />
             <p className="text-xs text-slate-500">
-              {MENTORSHIP_CONFIG.price}€/Monat · monatlich kündbar ·{" "}
-              <span className="rounded-sm bg-yellow-200 px-1 text-blue-700">max. {MENTORSHIP_CONFIG.maxSpots} Plätze</span>
+              Kostenlos anmelden → Konditionen prüfen → sicher über Stripe buchen
             </p>
           </div>
         </div>

--- a/components/sections/lazy-final-cta-section.tsx
+++ b/components/sections/lazy-final-cta-section.tsx
@@ -55,15 +55,13 @@ function FinalCtaFallback() {
               <span className="text-xs sm:text-sm font-medium text-blue-400">Jetzt starten</span>
             </div>
           </div>
-          <h2 className="text-2xl sm:text-4xl md:text-5xl font-bold text-white mb-4 sm:mb-6">
-            Deine Trading-Reise <br />
-            <span className="text-blue-400">
-              {MENTORSHIP_IS_UPCOMING ? `Beginnt im ${MENTORSHIP_CONFIG.startMonthYear}` : 'Beginnt jetzt'}
-            </span>
+          <h2 className="text-balance text-2xl font-bold text-white sm:text-4xl md:text-5xl">
+            Bereit, ICT <span className="text-blue-400">live anzuwenden?</span>
           </h2>
-          <p className="text-sm sm:text-xl text-gray-300 max-w-2xl mx-auto">
-            Werde einer von {MENTORSHIP_CONFIG.maxSpots} ambitionierten Tradern und erlebe ein transformatives Jahr
-            mit Live-Marktanalysen, Echtzeit-Trading und messbarem Wachstum.
+          <p className="mx-auto mt-4 max-w-2xl text-pretty text-sm text-gray-300 sm:mt-6 sm:text-xl">
+            {MENTORSHIP_IS_UPCOMING
+              ? `Melde dich für den Start im ${MENTORSHIP_CONFIG.startMonthYear} an und sichere dir Zugang zu Live-Sessions, Aufzeichnungen und Community.`
+              : 'Steig in die laufende Mentorship ein und erhalte Zugang zu Live-Sessions, Aufzeichnungen und Community.'}
           </p>
         </div>
 
@@ -84,10 +82,10 @@ function FinalCtaFallback() {
 
         <div className="text-center">
           <div className="inline-flex h-12 items-center justify-center rounded-md bg-white/90 px-6 text-sm font-medium text-slate-900 sm:h-14 sm:px-8 sm:text-lg">
-            Prüfen ob Plätze frei sind
+            Einstieg starten
           </div>
           <p className="mt-4 sm:mt-6 text-xs sm:text-base text-gray-400">
-            {MENTORSHIP_IS_UPCOMING ? 'Keine Zahlung bis zum Programmstart.' : MENTORSHIP_CONFIG.paymentNote}
+            Kostenlos anmelden → Konditionen prüfen → sicher über Stripe buchen
           </p>
         </div>
       </div>

--- a/components/sections/mentorship-entry-cta.tsx
+++ b/components/sections/mentorship-entry-cta.tsx
@@ -1,0 +1,108 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { SignInButton, useUser } from '@clerk/nextjs'
+import { ArrowRight } from '@phosphor-icons/react/ArrowRight'
+import { SpinnerGap } from '@phosphor-icons/react/SpinnerGap'
+import { useRouter } from 'next/navigation'
+import { trackConversion } from '@/components/analytics/tracking'
+import { Button, type ButtonProps } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+type MentorshipEntryCtaProps = Pick<ButtonProps, 'size' | 'variant'> & {
+  className?: string
+  label?: string
+  source: string
+}
+
+export function MentorshipEntryCta({
+  className,
+  label = 'Einstieg starten',
+  size = 'lg',
+  source,
+  variant = 'default',
+}: MentorshipEntryCtaProps) {
+  const { isLoaded, isSignedIn } = useUser()
+  const router = useRouter()
+  const [isNavigating, setIsNavigating] = useState(false)
+  const navigationTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (navigationTimeoutRef.current !== null) {
+        window.clearTimeout(navigationTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleSignedInClick = () => {
+    if (isNavigating) return
+
+    trackConversion.ctaClick(source)
+    setIsNavigating(true)
+    router.push('/dashboard')
+
+    navigationTimeoutRef.current = window.setTimeout(() => {
+      setIsNavigating(false)
+      navigationTimeoutRef.current = null
+    }, 1200)
+  }
+
+  const handleSignInClick = () => {
+    trackConversion.ctaClick(source)
+    trackConversion.signInStart(source)
+  }
+
+  const buttonContent = (
+    <>
+      <span>{label}</span>
+      {isNavigating ? (
+        <SpinnerGap aria-hidden="true" className="h-4 w-4 animate-spin motion-reduce:animate-none" />
+      ) : (
+        <ArrowRight aria-hidden="true" className="h-4 w-4" />
+      )}
+    </>
+  )
+
+  const buttonClassName = cn('touch-manipulation', className)
+
+  if (!isLoaded) {
+    return (
+      <Button disabled size={size} variant={variant} className={buttonClassName}>
+        <span>{label}</span>
+        <ArrowRight aria-hidden="true" className="h-4 w-4" />
+      </Button>
+    )
+  }
+
+  if (isSignedIn) {
+    return (
+      <Button
+        type="button"
+        size={size}
+        variant={variant}
+        className={buttonClassName}
+        disabled={isNavigating}
+        aria-busy={isNavigating}
+        aria-label={isNavigating ? 'Einstieg wird geöffnet' : undefined}
+        onClick={handleSignedInClick}
+      >
+        {buttonContent}
+      </Button>
+    )
+  }
+
+  return (
+    <SignInButton mode="modal" forceRedirectUrl="/dashboard">
+      <Button
+        type="button"
+        size={size}
+        variant={variant}
+        className={buttonClassName}
+        onClick={handleSignInClick}
+      >
+        {buttonContent}
+      </Button>
+    </SignInButton>
+  )
+}

--- a/components/sections/pricing-comparison-cta.tsx
+++ b/components/sections/pricing-comparison-cta.tsx
@@ -1,33 +1,7 @@
-'use client'
-
-import { SignInButton, useUser } from '@clerk/nextjs'
-import { ArrowRight } from '@phosphor-icons/react/ArrowRight'
-import { useRouter } from 'next/navigation'
-import { Button } from '@/components/ui/button'
+import { MentorshipEntryCta } from '@/components/sections/mentorship-entry-cta'
 
 export function PricingComparisonCta() {
-  const { isSignedIn } = useUser()
-  const router = useRouter()
-
-  if (isSignedIn) {
-    return (
-      <Button
-        size="lg"
-        onClick={() => router.push('/dashboard')}
-        className="gap-2"
-      >
-        Jetzt Platz sichern
-        <ArrowRight className="h-4 w-4" />
-      </Button>
-    )
-  }
-
   return (
-    <SignInButton mode="modal" forceRedirectUrl="/dashboard">
-      <Button size="lg" className="gap-2">
-        Jetzt Platz sichern
-        <ArrowRight className="h-4 w-4" />
-      </Button>
-    </SignInButton>
+    <MentorshipEntryCta source="comparison_cta" />
   )
 }

--- a/components/sections/pricing-comparison.tsx
+++ b/components/sections/pricing-comparison.tsx
@@ -71,7 +71,7 @@ const comparisonData: { categories: Category[] } = {
         },
         {
           name: "Kündigungsbedingungen",
-          us: "Jederzeit kündbar",
+          us: "1 Tag Frist zum Monatsende",
           others: "Keine Kündigung",
           highlight: true,
           description: "Flexible Bindung vs. feste Vertragslaufzeit"
@@ -123,7 +123,7 @@ const comparisonData: { categories: Category[] } = {
         },
         {
           name: "Community-Größe",
-          us: "Limitiert auf 100",
+          us: "Fokussierte Community",
           others: "Unbegrenzt",
           highlight: true,
           description: "Fokussierte Gruppe vs. überfüllte Community"
@@ -245,6 +245,9 @@ export default function PricingComparison() {
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <PricingComparisonCta />
           </div>
+          <p className="text-sm leading-relaxed text-gray-500">
+            Kostenlos anmelden → Konditionen prüfen → sicher über Stripe buchen
+          </p>
         </div>
       </div>
     </section>

--- a/components/sections/pricing.tsx
+++ b/components/sections/pricing.tsx
@@ -1,7 +1,7 @@
-import { MENTORSHIP_CONFIG } from '@/lib/config'
+import { MENTORSHIP_CONFIG, MENTORSHIP_IS_UPCOMING } from '@/lib/config'
 import { Check } from "@phosphor-icons/react/dist/ssr/Check"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
+import { MentorshipEntryCta } from '@/components/sections/mentorship-entry-cta'
 
 const features = [
   "2 Live-Sessions pro Woche (Di + Do)",
@@ -9,7 +9,7 @@ const features = [
   "Tagesausblick am Dienstag und Donnerstag",
   "3-4 vollständige Trading-Modelle mit Trading Plan",
   "Alle Recordings verfügbar solange du dabei bist",
-  `Exklusive Community (max. ${MENTORSHIP_CONFIG.maxSpots} Trader)`,
+  "Fokussierte Community für Austausch und Feedback",
 ]
 
 export default function Pricing() {
@@ -29,7 +29,7 @@ export default function Pricing() {
           
           <div className="absolute top-0 right-0 mr-6 -mt-4">
             <span className="inline-flex items-center rounded-full bg-blue-50 px-4 py-1 text-sm font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10">
-              Nur {MENTORSHIP_CONFIG.maxSpots} Plätze
+              {MENTORSHIP_IS_UPCOMING ? 'Warteliste geöffnet' : 'Laufender Jahrgang'}
             </span>
           </div>
           
@@ -47,7 +47,7 @@ export default function Pricing() {
             <div className="bg-blue-50/50 border-l-4 border-blue-500 p-6 rounded-r-lg">
               <p className="text-gray-700 leading-relaxed italic">
                 Kein 3.000€ Kurs den du im Voraus bezahlst und danach bist du auf dich alleine gestellt. 
-                Du zahlst monatlich — wenn ich als Mentor nicht liefere, kannst du jederzeit gehen. 
+                Du zahlst monatlich — wenn ich als Mentor nicht liefere, kannst du zum Monatsende gehen.
                 Das Risiko liegt bei mir.
               </p>
             </div>
@@ -62,9 +62,13 @@ export default function Pricing() {
             </ul>
 
             <div className="pt-4">
-              <Button className="w-full" size="lg">
-                Prüfen ob Plätze frei sind
-              </Button>
+              <MentorshipEntryCta
+                source="pricing_cta"
+                className="w-full"
+              />
+              <p className="mt-3 text-center text-sm leading-relaxed text-gray-500">
+                Kostenlos anmelden → Konditionen prüfen → sicher über Stripe buchen
+              </p>
             </div>
           </CardContent>
         </Card>

--- a/components/sections/why-different.tsx
+++ b/components/sections/why-different.tsx
@@ -15,7 +15,7 @@ const features = [
   {
     icon: <Calendar className="h-4 w-4 sm:h-6 sm:w-6" />,
     title: "Live Sessions",
-    description: "2-3 Live-Sessions pro Woche für Lektionen, Übungen und Live-Trading.",
+    description: `${MENTORSHIP_CONFIG.sessionsPerWeek} Live-Sessions pro Woche für Lektionen, Übungen und Live-Trading.`,
   },
   {
     icon: <Users className="h-4 w-4 sm:h-6 sm:w-6" />,
@@ -29,8 +29,8 @@ const features = [
   },
   {
     icon: <Trophy className="h-4 w-4 sm:h-6 sm:w-6" />,
-    title: "Unbefristeter Zugang",
-    description: "Schließe das einjährige Programm ab und erhalte dauerhaften Zugriff auf alle Materialien.",
+    title: "Aufzeichnungen inklusive",
+    description: "Greife während deiner Mitgliedschaft auf alle Materialien und bisherigen Sessions zu.",
   },
   {
     icon: <CreditCard className="h-4 w-4 sm:h-6 sm:w-6" />,
@@ -62,7 +62,7 @@ function FeatureCard({ feature }: { feature: typeof features[0] }) {
 
 export default function WhyDifferent() {
   return (
-    <section id="why-different" className="py-16 sm:py-24 bg-slate-900">
+    <section id="why-different" className="scroll-mt-20 py-16 sm:py-24 bg-slate-900">
       <div className="container mx-auto px-4 max-w-6xl">
         <div className="text-center mb-8 sm:mb-16">
           <div className="inline-flex items-center gap-1.5 sm:gap-2 pl-1.5 sm:pl-2 pr-3 sm:pr-4 py-1 rounded-full bg-white/10 ring-1 ring-white/20 mb-4 sm:mb-6">

--- a/components/seo/json-ld.tsx
+++ b/components/seo/json-ld.tsx
@@ -1,3 +1,5 @@
+import { MENTORSHIP_CONFIG } from '@/lib/config'
+
 export function JsonLd() {
   const organizationSchema = {
     '@context': 'https://schema.org',
@@ -17,7 +19,7 @@ export function JsonLd() {
     '@type': 'Course',
     name: 'PAT Mentorship 2026',
     description:
-      'Live-Mentoring-Programm für Trading nach ICT Smart Money Konzepten. 2-3 Live-Sessions pro Woche, auf Deutsch.',
+      `Live-Mentoring-Programm für Trading nach ICT Smart Money Konzepten. ${MENTORSHIP_CONFIG.sessionsPerWeek} Live-Sessions pro Woche, auf Deutsch.`,
     provider: {
       '@type': 'Organization',
       name: 'Price Action Trader',
@@ -35,9 +37,9 @@ export function JsonLd() {
     educationalLevel: 'Beginner to Advanced',
     offers: {
       '@type': 'Offer',
-      price: '150.00',
-      priceCurrency: 'EUR',
-      availability: 'https://schema.org/LimitedAvailability',
+      price: MENTORSHIP_CONFIG.price.toFixed(2),
+      priceCurrency: MENTORSHIP_CONFIG.currency,
+      availability: 'https://schema.org/InStock',
       url: 'https://price-action-trader.de',
     },
     aggregateRating: {
@@ -58,7 +60,7 @@ export function JsonLd() {
         name: 'Was ist das PAT Mentorship?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Das PAT Mentorship ist ein Live-Mentoring-Programm für Trading nach ICT Smart Money Konzepten. Du lernst in 2-3 Live-Sessions pro Woche, auf Deutsch, direkt von Mentor Petar.',
+          text: `Das PAT Mentorship ist ein Live-Mentoring-Programm für Trading nach ICT Smart Money Konzepten. Du lernst in ${MENTORSHIP_CONFIG.sessionsPerWeek} Live-Sessions pro Woche, auf Deutsch, direkt von Mentor Petar.`,
         },
       },
       {
@@ -66,7 +68,7 @@ export function JsonLd() {
         name: 'Wie viel kostet das Mentorship?',
         acceptedAnswer: {
           '@type': 'Answer',
-          text: 'Das PAT Mentorship kostet 150 € pro Monat und ist monatlich kündbar. Es gibt keine langfristigen Verträge.',
+          text: `Das PAT Mentorship kostet ${MENTORSHIP_CONFIG.price} € pro Monat und ist mit 1 Tag Frist zum Monatsende kündbar. Es gibt keine langfristigen Verträge.`,
         },
       },
       {

--- a/components/ui/checkout-button.tsx
+++ b/components/ui/checkout-button.tsx
@@ -7,15 +7,23 @@ import { trackConversion } from '@/components/analytics/tracking'
 
 interface CheckoutButtonProps {
   disabled?: boolean
+  disabledReason?: string
+  label?: string
 }
 
-export function CheckoutButton({ disabled = false }: CheckoutButtonProps) {
+export function CheckoutButton({
+  disabled = false,
+  disabledReason,
+  label = 'Weiter zur sicheren Zahlung',
+}: CheckoutButtonProps) {
   const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const checkoutAbortRef = useRef<AbortController | null>(null)
 
   useEffect(() => {
     return () => {
       checkoutAbortRef.current?.abort()
+      checkoutAbortRef.current = null
     }
   }, [])
 
@@ -26,10 +34,18 @@ export function CheckoutButton({ disabled = false }: CheckoutButtonProps) {
     const controller = new AbortController()
     checkoutAbortRef.current = controller
 
+    setErrorMessage(null)
     setIsLoading(true)
     
     // Track Checkout-Start für Google Ads Conversion
     trackConversion.checkoutStart()
+
+    let didRedirect = false
+    let didTimeout = false
+    const timeoutId = window.setTimeout(() => {
+      didTimeout = true
+      controller.abort()
+    }, 15000)
 
     try {
       const response = await fetch('/api/create-checkout', {
@@ -48,34 +64,59 @@ export function CheckoutButton({ disabled = false }: CheckoutButtonProps) {
         throw new Error('Checkout-URL fehlt')
       }
 
-      window.location.href = url
+      didRedirect = true
+      window.location.assign(url)
     } catch (error) {
-      if (controller.signal.aborted) return
+      if (controller.signal.aborted && !didTimeout) return
       console.error('Error starting checkout:', error)
-      setIsLoading(false)
-      alert('Fehler beim Starten des Checkouts. Bitte versuche es später erneut.')
+      setErrorMessage(
+        didTimeout
+          ? 'Der Checkout antwortet gerade nicht. Bitte prüfe deine Verbindung und versuche es erneut.'
+          : 'Der Checkout konnte nicht geöffnet werden. Bitte versuche es erneut oder lade die Seite neu.'
+      )
     } finally {
+      window.clearTimeout(timeoutId)
       if (checkoutAbortRef.current === controller) {
         checkoutAbortRef.current = null
+        if (!didRedirect) {
+          setIsLoading(false)
+        }
       }
     }
   }
 
+  const feedbackMessage = errorMessage ?? (!isLoading && disabled ? disabledReason : null)
+
   return (
-    <Button
-      onClick={handleCheckout}
-      disabled={isLoading || disabled}
-      className="w-full text-lg py-6"
-      size="lg"
-    >
-      {isLoading ? (
-        <>
-          <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-          Wird weitergeleitet...
-        </>
-      ) : (
-        'Jetzt Platz sichern'
-      )}
-    </Button>
+    <div className="space-y-2">
+      <Button
+        type="button"
+        onClick={handleCheckout}
+        disabled={isLoading || disabled}
+        aria-busy={isLoading}
+        aria-describedby={feedbackMessage ? 'checkout-button-feedback' : undefined}
+        className="w-full touch-manipulation py-6 text-base sm:text-lg"
+        size="lg"
+      >
+        {isLoading ? (
+          <>
+            <Loader2 aria-hidden="true" className="mr-2 h-5 w-5 animate-spin motion-reduce:animate-none" />
+            Stripe wird geöffnet…
+          </>
+        ) : (
+          label
+        )}
+      </Button>
+      {feedbackMessage ? (
+        <p
+          id="checkout-button-feedback"
+          role={errorMessage ? 'alert' : 'status'}
+          aria-live={errorMessage ? 'assertive' : 'polite'}
+          className={errorMessage ? 'text-sm text-red-700' : 'text-sm text-gray-600'}
+        >
+          {feedbackMessage}
+        </p>
+      ) : null}
+    </div>
   )
 }

--- a/components/ui/hero-pill.tsx
+++ b/components/ui/hero-pill.tsx
@@ -83,6 +83,7 @@ export function HeroPill({
       <a
         href={href}
         target={isExternal ? "_blank" : undefined}
+        rel={isExternal ? "noopener noreferrer" : undefined}
         className={cn(
           "inline-flex w-fit items-center space-x-2 rounded-full",
           "pl-2 pr-3 py-1 whitespace-nowrap",
@@ -92,6 +93,7 @@ export function HeroPill({
       >
         {content}
         <svg
+          aria-hidden="true"
           width="12"
           height="12"
           className="ml-1"

--- a/components/ui/particle-text-effect.tsx
+++ b/components/ui/particle-text-effect.tsx
@@ -144,7 +144,7 @@ const DRAW_AS_POINTS = true
 
 export function ParticleTextEffect({ words = DEFAULT_WORDS }: ParticleTextEffectProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const animationRef = useRef<number>()
+  const animationRef = useRef<number | undefined>(undefined)
   const animateRef = useRef<() => void>(() => {})
   const particlesRef = useRef<Particle[]>([])
   const frameCountRef = useRef(0)

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -18,9 +18,9 @@ export const MENTORSHIP_CONFIG = {
   startDateFormatted: '01.03.2026',
   startMonthYear: 'März 2026',
   enrollmentPhase: 'active' as MentorshipEnrollmentPhase,
-  enrollmentLabel: 'Laufender Jahrgang • Einstieg nach Verfügbarkeit',
-  enrollmentLabelEn: 'Program in progress • Entry subject to availability',
-  paymentNote: 'Monatlich kündbar. Zugang nach erfolgreicher Freischaltung.',
+  enrollmentLabel: 'Laufender Jahrgang • Einstieg möglich',
+  enrollmentLabelEn: 'Program in progress • Enrollment open',
+  paymentNote: 'Monatlich kündbar mit 1 Tag Frist zum Monatsende. Zugang nach erfolgreicher Freischaltung.',
 
   // Content
   sessionsPerWeek: '2',


### PR DESCRIPTION
## Was geändert

- Mobile Hero neu priorisiert: Nutzen, Preis, Social Proof und CTA liegen vor dem Bild im ersten Viewport.
- Desktop-Partikelanimation vollständig beibehalten; Partikel-Canvas wird mobil nicht initialisiert.
- Einheitlichen `MentorshipEntryCta` für Hero, Pricing, Vergleich, LP und Final CTA eingeführt.
- Funktionslosen Pricing-CTA repariert und CTA-Tracking nach Quelle differenziert.
- Dashboard-Checkout mit klarer 3-Schritt-Führung, konkretem Stripe-CTA und erklärtem Disabled-State überarbeitet.
- Inline-Fehler, Timeout, Retry-Hinweise sowie saubere Zustände für Checkout-Abbruch und verzögerte Zahlungsbestätigung ergänzt.
- Purchase-Tracking und Success-Modal an ein bestätigtes aktives Abo gekoppelt.
- Nicht technisch belegte Knappheits- und Lifetime-Access-Claims entfernt; Preis, Sessions und Kündigungsfrist zentral konsistent gemacht.
- Zwei bestehende TypeScript-Build-Blocker minimal bereinigt.

## Warum

Der mobile Primär-CTA lag bislang typischerweise unterhalb des ersten Viewports. Zusätzlich waren CTA-Versprechen uneinheitlich, der wichtigste Pricing-Button ohne Aktion und mehrere Checkout-Zustände missverständlich oder nur per Browser-Alert sichtbar.

## Validierung

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- Browser-QA bei 375 px, 768 px und 1440 px
- CTA-Login-Übergang und Pricing-CTA geprüft
- Checkout-Checkbox/Disabled-State, Abbruch- und Pending-Status geprüft
- Keine Browserfehler oder Layout-Overflows
- Desktop-Hero: Partikel aktiv; Mobile-Hero: kein Partikel-Canvas
