### PR TITLE
Fix Raid Map mobile first viewport

### DIFF
--- a/app/raid-map/de/page.tsx
+++ b/app/raid-map/de/page.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 export default function RaidMapPageDe() {
   const hasGuideImage = fs.existsSync(path.join(process.cwd(), 'public', RAIDMAP_CONFIG.guideImagePath))
   return (
-    <main>
+    <div lang="de">
       <Suspense fallback={null}>
         <RaidMapSuccessDialog lang="de" hasGuideImage={hasGuideImage} />
       </Suspense>
@@ -48,6 +48,6 @@ export default function RaidMapPageDe() {
       <RaidMapPricing lang="de" />
       <RaidMapTestimonials lang="de" />
       <RaidMapFaq lang="de" />
-    </main>
+    </div>
   )
 }

--- a/app/raid-map/page.tsx
+++ b/app/raid-map/page.tsx
@@ -61,7 +61,7 @@ const productJsonLd = {
 export default function RaidMapPageEn() {
   const hasGuideImage = fs.existsSync(path.join(process.cwd(), 'public', RAIDMAP_CONFIG.guideImagePath))
   return (
-    <main>
+    <div lang="en">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(productJsonLd) }}
@@ -76,6 +76,6 @@ export default function RaidMapPageEn() {
       <RaidMapPricing lang="en" />
       <RaidMapTestimonials lang="en" />
       <RaidMapFaq lang="en" />
-    </main>
+    </div>
   )
 }

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -103,6 +103,8 @@ export function Navbar() {
     ? RAIDMAP_CONFIG.accountPathDe
     : RAIDMAP_CONFIG.accountPath
   const raidMapAccountLabel = isRaidMapGerman ? 'Mein Raid Map Account' : 'My Raid Map account'
+  const signInLabel = isRaidMap && !isRaidMapGerman ? 'Sign in →' : 'Anmelden →'
+  const signInRedirectUrl = isRaidMap ? raidMapAccountPath : '/dashboard'
   const isAdmin = user?.organizationMemberships?.some(
     membership => membership.role === 'org:admin'
   )
@@ -242,7 +244,7 @@ export function Navbar() {
             {/* Logo */}
             <Link 
               href="/" 
-              className="flex items-center gap-3 group hover:opacity-90 transition-opacity"
+              className="group flex min-h-11 items-center gap-3 transition-opacity hover:opacity-90"
             >
               <Image
                 src="/images/hero/PAT-logo.png"
@@ -346,17 +348,9 @@ export function Navbar() {
                 </div>
               ) : (
                 <div className="flex items-center gap-3">
-                  {isRaidMap && !isRaidMapAccount ? (
-                    <Button asChild variant="outline" className="flex items-center gap-2">
-                      <Link href={raidMapAccountPath} prefetch={false}>
-                        <CreditCard className="h-4 w-4" />
-                        <span>{raidMapAccountLabel}</span>
-                      </Link>
-                    </Button>
-                  ) : null}
-                  <SignInButton mode="modal" forceRedirectUrl={"/dashboard"}>
+                  <SignInButton mode="modal" forceRedirectUrl={signInRedirectUrl}>
                     <Button>
-                      Anmelden →
+                      {signInLabel}
                     </Button>
                   </SignInButton>
                 </div>
@@ -368,7 +362,7 @@ export function Navbar() {
               {isSignedIn ? (
                 <>
                   {isRaidMap && !isRaidMapAccount ? (
-                    <Button asChild variant="outline" size="sm" className="flex items-center gap-2 px-3">
+                    <Button asChild variant="outline" size="sm" className="flex min-h-11 items-center gap-2 px-3">
                       <Link href={raidMapAccountPath} prefetch={false}>
                         <CreditCard className="h-4 w-4" />
                         <span>Account</span>
@@ -378,7 +372,7 @@ export function Navbar() {
                   {!isMentorship || isAdmin ? (
                     <button
                       onClick={() => setIsOpen(!isOpen)}
-                      className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+                      className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg p-2 transition-colors hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-2"
                       aria-label={isOpen ? 'Menü schließen' : 'Menü öffnen'}
                       aria-expanded={isOpen}
                     >
@@ -400,17 +394,9 @@ export function Navbar() {
                 </>
               ) : (
                 <>
-                  {isRaidMap && !isRaidMapAccount ? (
-                    <Button asChild variant="outline" size="sm" className="flex items-center gap-2 px-3">
-                      <Link href={raidMapAccountPath} prefetch={false}>
-                        <CreditCard className="h-4 w-4" />
-                        <span>Account</span>
-                      </Link>
-                    </Button>
-                  ) : null}
-                  <SignInButton mode="modal" forceRedirectUrl={"/dashboard"}>
-                    <Button size="sm">
-                      Anmelden →
+                  <SignInButton mode="modal" forceRedirectUrl={signInRedirectUrl}>
+                    <Button size="sm" className="min-h-11 px-4">
+                      {signInLabel}
                     </Button>
                   </SignInButton>
                 </>

--- a/components/sections/raidmap/chart-tour.tsx
+++ b/components/sections/raidmap/chart-tour.tsx
@@ -10,7 +10,7 @@ export default function RaidMapChartTour({ lang }: { lang: RaidMapLang }) {
   const t = raidmapChartTour[lang]
 
   return (
-    <section id="chart-tour" className="py-20 px-4 md:px-6 bg-white">
+    <section id="chart-tour" className="scroll-mt-20 bg-white px-4 py-14 md:px-6 md:py-20">
       <div className="container mx-auto max-w-5xl">
         <div className="max-w-3xl mb-10">
           <h2 className="text-3xl md:text-4xl font-bold text-gray-900 text-balance">{t.title}</h2>

--- a/components/sections/raidmap/hero.tsx
+++ b/components/sections/raidmap/hero.tsx
@@ -1,4 +1,6 @@
+import Image from 'next/image'
 import Link from 'next/link'
+import { ArrowRight } from '@phosphor-icons/react/dist/ssr/ArrowRight'
 import { Check } from '@phosphor-icons/react/dist/ssr/Check'
 import { Button } from '@/components/ui/button'
 import { RAIDMAP_CONFIG, type RaidMapLang } from '@/lib/raidmap-config'
@@ -9,56 +11,100 @@ export default function RaidMapHero({ lang }: { lang: RaidMapLang }) {
   const proof = raidmapProof[lang]
   const ui = raidmapUi[lang]
   const docsHref = lang === 'en' ? RAIDMAP_CONFIG.docsPathEn : RAIDMAP_CONFIG.docsPathDe
+  const compactBadge = lang === 'en'
+    ? 'TradingView · NQ · OOS tested'
+    : 'TradingView · NQ · OOS-getestet'
+  const localeShortLabel = lang === 'en' ? 'DE' : 'EN'
+  const previewLabel = lang === 'en' ? 'Live NQ chart' : 'Live-NQ-Chart'
+  const previewAlt = lang === 'en'
+    ? 'PAT Raid Map preview on a live NQ chart'
+    : 'PAT Raid Map Vorschau auf einem Live-NQ-Chart'
 
   return (
-    <section className="pt-16 pb-12 px-4 md:px-6 bg-white">
-      <div className="container mx-auto max-w-5xl">
-        <div className="flex items-center justify-between gap-4 mb-10">
-          <span className="inline-flex items-center rounded-full bg-blue-50 px-4 py-1 text-sm font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10">
-            {t.badge}
+    <section data-raidmap-hero className="bg-white px-4 pb-10 pt-8 sm:pt-10 md:px-6 md:pb-14 md:pt-16">
+      <div className="mx-auto w-full max-w-5xl">
+        <div className="mb-7 flex items-center justify-between gap-3 md:mb-10">
+          <span className="inline-flex min-w-0 items-center rounded-full bg-blue-50 px-3 py-1.5 text-xs font-semibold text-blue-700 ring-1 ring-inset ring-blue-700/10 sm:px-4 sm:text-sm">
+            <span className="sm:hidden">{compactBadge}</span>
+            <span className="hidden sm:inline">{t.badge}</span>
           </span>
           <Link
             href={ui.langSwitchHref}
-            className="text-sm text-gray-500 underline underline-offset-4 hover:text-gray-900"
+            aria-label={ui.langSwitch}
+            className="inline-flex min-h-8 shrink-0 items-center justify-center rounded-full border border-gray-200 bg-white px-3 text-xs font-semibold text-gray-600 shadow-sm transition-colors hover:border-gray-300 hover:text-gray-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 sm:text-sm"
           >
-            {ui.langSwitch}
+            <span className="sm:hidden">{localeShortLabel}</span>
+            <span className="hidden sm:inline">{ui.langSwitch}</span>
           </Link>
         </div>
 
-        <h1 className="text-4xl md:text-6xl font-bold text-gray-900 text-balance">
-          {t.title}
-        </h1>
-        <p className="mt-6 text-lg md:text-xl text-gray-600 max-w-3xl text-pretty">
-          {t.subtitle}
-        </p>
+        <div className="grid items-start gap-x-10 lg:grid-cols-2 lg:grid-rows-[auto_auto] xl:gap-x-14">
+          <div className="lg:col-start-1 lg:row-start-1">
+            <h1 className="text-[2.5rem] font-bold leading-[1.04] text-gray-950 text-balance sm:text-5xl md:text-6xl md:leading-[1.02]">
+              {t.title}
+            </h1>
+            <p className="mt-5 max-w-2xl text-base leading-7 text-gray-600 text-pretty sm:text-lg md:mt-6 md:text-xl md:leading-8">
+              {t.subtitle}
+            </p>
+          </div>
 
-        <ul className="mt-8 space-y-3">
+          <div className="mt-5 overflow-hidden rounded-xl border border-gray-200 bg-gray-950 shadow-sm lg:col-start-2 lg:row-span-2 lg:row-start-1 lg:mt-0 lg:self-center">
+            <div className="relative aspect-[2/1] lg:aspect-[1.65/1]">
+              <Image
+                src="/images/raidmap/chart-example.png"
+                alt={previewAlt}
+                width={1952}
+                height={1186}
+                priority
+                sizes="(max-width: 1023px) calc(100vw - 32px), 560px"
+                className="h-full w-full object-cover object-center"
+              />
+              <span className="absolute left-3 top-3 rounded-full bg-gray-950/85 px-2.5 py-1 text-[11px] font-semibold text-white shadow-sm backdrop-blur-sm">
+                {previewLabel}
+              </span>
+            </div>
+          </div>
+
+          <div className="mt-5 lg:col-start-1 lg:row-start-2 lg:mt-7">
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Button asChild size="lg" className="min-h-12 w-full px-6 text-base sm:w-auto sm:px-8 sm:text-lg">
+                <Link href="#pricing">
+                  {t.ctaPrimary}
+                  <ArrowRight aria-hidden="true" />
+                </Link>
+              </Button>
+              <Button asChild size="lg" variant="outline" className="hidden min-h-12 px-6 text-base sm:inline-flex sm:px-8 sm:text-lg">
+                <Link href={docsHref}>{t.ctaSecondary}</Link>
+              </Button>
+              <Link
+                href={docsHref}
+                className="inline-flex min-h-8 items-center justify-center gap-1.5 text-sm font-semibold text-gray-700 underline decoration-gray-300 underline-offset-4 hover:text-gray-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 sm:hidden"
+              >
+                {t.ctaSecondary}
+                <ArrowRight aria-hidden="true" />
+              </Link>
+            </div>
+
+            <p className="mt-3 text-xs font-semibold leading-5 text-blue-700 sm:text-sm">{t.urgency}</p>
+          </div>
+        </div>
+
+        <ul className="mt-8 grid gap-4 border-t border-gray-100 pt-7 md:mt-10 md:grid-cols-3 md:gap-6 md:pt-8">
           {t.bullets.map((b) => (
             <li key={b} className="flex items-start gap-3">
-              <Check className="size-5 text-blue-600 flex-shrink-0 mt-0.5" />
-              <span className="text-gray-700 text-pretty">{b}</span>
+              <Check aria-hidden="true" className="mt-0.5 size-5 flex-shrink-0 text-blue-600" />
+              <span className="text-sm leading-6 text-gray-700 text-pretty sm:text-base">{b}</span>
             </li>
           ))}
         </ul>
 
-        <div className="mt-10 flex flex-col sm:flex-row gap-4">
-          <Button asChild size="lg" className="text-lg px-8">
-            <Link href="#pricing">{t.ctaPrimary}</Link>
-          </Button>
-          <Button asChild size="lg" variant="outline" className="text-lg px-8">
-            <Link href={docsHref}>{t.ctaSecondary}</Link>
-          </Button>
-        </div>
+        <p className="mt-7 max-w-2xl text-xs leading-5 text-gray-400 text-pretty">{t.finePrint}</p>
 
-        <p className="mt-4 text-sm font-medium text-blue-700">{t.urgency}</p>
-
-        <p className="mt-4 text-xs text-gray-400 max-w-2xl text-pretty">{t.finePrint}</p>
-
-        <dl className="mt-14 grid grid-cols-2 md:grid-cols-4 gap-6 border-t border-gray-100 pt-10">
+        <dl className="mt-10 grid grid-cols-2 gap-5 border-t border-gray-100 pt-8 md:mt-14 md:grid-cols-4 md:gap-6 md:pt-10">
           {proof.items.map((item) => (
             <div key={item.label}>
               <dt className="sr-only">{item.label}</dt>
-              <dd className="text-2xl md:text-3xl font-bold text-gray-900 tabular-nums">
+              <dd className="text-2xl font-bold text-gray-900 tabular-nums md:text-3xl">
                 {item.value}
               </dd>
               <p className="mt-1 text-sm text-gray-500">{item.label}</p>

--- a/components/sections/raidmap/pricing.tsx
+++ b/components/sections/raidmap/pricing.tsx
@@ -15,7 +15,7 @@ export default function RaidMapPricing({ lang }: { lang: RaidMapLang }) {
   const c = RAIDMAP_CONFIG
 
   return (
-    <section id="pricing" className="py-20 px-4 md:px-6 bg-gray-50">
+    <section id="pricing" className="scroll-mt-20 bg-gray-50 px-4 py-20 md:px-6">
       <div className="container mx-auto max-w-5xl">
         <div className="text-center mb-14">
           <span className="inline-flex items-center rounded-full bg-blue-600 px-4 py-1 text-sm font-medium text-white">

--- a/components/sections/raidmap/success-dialog.tsx
+++ b/components/sections/raidmap/success-dialog.tsx
@@ -43,7 +43,7 @@ export function RaidMapSuccessDialog({ lang, hasGuideImage }: { lang: RaidMapLan
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="max-w-2xl max-h-[85dvh] overflow-y-auto">
+      <DialogContent lang={lang} className="max-h-[85dvh] max-w-2xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-2xl">{t.title}</DialogTitle>
           <DialogDescription className="text-pretty">{t.description}</DialogDescription>

--- a/lib/raidmap-content.ts
+++ b/lib/raidmap-content.ts
@@ -45,7 +45,7 @@ export const raidmapHero: L<{
     badge: 'TradingView indicator · NQ · invite-only · out-of-sample tested',
     title: 'Stop guessing the bias. Read the session like a map.',
     subtitle:
-      'The PAT Raid Map shows the three things that actually decide your session: which level gets raided first, when the run typically starts, and what happens after the purge. Every number on your chart survived a placebo test on 10 years of NQ data — or it was deleted.',
+      'See the likely first raid, the validated run window, and the post-purge path directly on your TradingView chart — backed by 10 years of NQ data.',
     bullets: [
       'First-target map: the most likely first stop of the session, ranked by 10 years of level races',
       'Run-timing windows: the validated minutes when the move actually tends to happen',
@@ -61,7 +61,7 @@ export const raidmapHero: L<{
     badge: 'TradingView-Indikator · NQ · invite-only · Out-of-Sample getestet',
     title: 'Hör auf, den Bias zu raten. Lies die Session wie eine Karte.',
     subtitle:
-      'Die PAT Raid Map zeigt dir die drei Dinge, die deine Session wirklich entscheiden: welches Level zuerst geraidet wird, wann der Run typischerweise startet und was nach dem Purge passiert. Jede Zahl auf deinem Chart hat einen Placebo-Test auf 10 Jahren NQ-Daten überlebt — oder sie wurde gelöscht.',
+      'Sieh den wahrscheinlichen ersten Raid, das validierte Run-Fenster und den Weg nach dem Purge direkt in deinem TradingView-Chart — belegt mit 10 Jahren NQ-Daten.',
     bullets: [
       'First-Target-Karte: der wahrscheinlichste erste Stopp der Session, gerankt aus 10 Jahren Level-Rennen',
       'Run-Timing-Fenster: die validierten Minuten, in denen die Bewegung typischerweise passiert',


### PR DESCRIPTION
## Was geändert

- Raid-Map-Hero für Mobile neu priorisiert: kurze Nutzenbotschaft, echter NQ-Chart und Primary CTA liegen jetzt vor den langen Detail-Bullets.
- Doppelte Mobile-Einrückung und übergroße Abstände reduziert; kompakter EN/DE-Switch ergänzt.
- Produkt-Chart als optimiertes Above-the-fold-Preview eingebunden, während die ausführliche Chart-Tour erhalten bleibt.
- Mobile Header-Navigation auf eine eindeutige Login-Aktion reduziert und EN/DE lokalisiert; Login führt direkt zum passenden Raid-Map-Account.
- EN/DE-Sprachbereiche und portalierten Checkout-Erfolgsdialog semantisch korrekt markiert.
- Pricing- und Chart-Anker erhalten sauberen Scroll-Offset; verschachtelte `main`-Elemente entfernt.

## Warum

Auf 390 px begann der Primary CTA bislang erst bei rund 985 px und lag damit unterhalb eines typischen 844-px-Viewports. Der erste Bildschirm zeigte fast ausschließlich Copy und keinen Produktbeweis. Die separate Raid-Map-Landingpage war von der vorherigen Mentorship-Hero-Optimierung nicht betroffen.

## Auswirkung

Bei 390 px liegt der echte Chart nun bei ca. 476–647 px und der Primary CTA bei ca. 668–716 px vollständig im ersten Viewport. Desktop behält die vollständige Produktstory und zeigt Hero-Copy und Chart als ruhige Zwei-Spalten-Komposition.

## Validierung

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- Browser-QA: 390 × 844, 768 × 1024 und 1440 × 900
- EN- und DE-Route geprüft
- CTA-Anker auf `#pricing` geprüft
- Kein horizontaler Overflow und keine Browser-Console-Errors
