### PR TITLE
feat: attach protected PDFs to lesson videos

### DIFF
--- a/app/api/download/pdf/[videoId]/[filename]/route.ts
+++ b/app/api/download/pdf/[videoId]/[filename]/route.ts
@@ -1,0 +1,108 @@
+import { auth } from '@clerk/nextjs/server'
+import { get } from '@vercel/blob'
+import { NextResponse } from 'next/server'
+import { getMentorshipAccessState } from '@/lib/mentorship-access'
+import { prisma } from '@/lib/prisma'
+import {
+  getLegacyPublicPdfUrl,
+  getPrivatePdfBlobPathname,
+  getStoredPdfFilename,
+} from '@/lib/protected-pdf'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const DOWNLOAD_TIMEOUT_MS = 15_000
+
+function downloadHeaders(filename: string, contentLength?: number | null, etag?: string | null) {
+  const safeFilename = filename.replace(/[\r\n"\\]/g, '').slice(0, 180) || 'document.pdf'
+  const headers = new Headers({
+    'Cache-Control': 'private, no-store, max-age=0',
+    'Content-Disposition': `attachment; filename="document.pdf"; filename*=UTF-8''${encodeURIComponent(safeFilename)}`,
+    'Content-Security-Policy': "default-src 'none'; sandbox",
+    'Content-Type': 'application/pdf',
+    Pragma: 'no-cache',
+    Vary: 'Cookie, Authorization',
+    'X-Content-Type-Options': 'nosniff',
+  })
+  if (typeof contentLength === 'number' && Number.isFinite(contentLength)) {
+    headers.set('Content-Length', String(contentLength))
+  }
+  if (etag) headers.set('ETag', etag)
+  return headers
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ videoId: string; filename: string }> }
+) {
+  const { userId, sessionClaims } = await auth()
+  if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const access = await getMentorshipAccessState(userId, sessionClaims)
+  if (!access.allowed) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const { videoId } = await params
+  if (!/^[A-Za-z0-9_-]{1,128}$/.test(videoId)) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const video = await prisma.video.findUnique({
+    where: { id: videoId },
+    select: { pdfUrl: true },
+  })
+  if (!video?.pdfUrl) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const filename = getStoredPdfFilename(video.pdfUrl)
+  const privatePathname = getPrivatePdfBlobPathname(video.pdfUrl, videoId)
+
+  if (privatePathname) {
+    const privateBlobToken = process.env.BLOB_PRIVATE_READ_WRITE_TOKEN?.trim()
+    if (!privateBlobToken) {
+      return NextResponse.json({ error: 'Private PDF storage is not configured' }, { status: 503 })
+    }
+
+    const result = await get(privatePathname, {
+      access: 'private',
+      token: privateBlobToken,
+      useCache: false,
+      ifNoneMatch: request.headers.get('if-none-match') ?? undefined,
+      abortSignal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    })
+    if (!result) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    if (result.statusCode === 304) {
+      return new Response(null, {
+        status: 304,
+        headers: downloadHeaders(filename, null, result.blob.etag),
+      })
+    }
+
+    return new Response(result.stream, {
+      status: 200,
+      headers: downloadHeaders(filename, result.blob.size, result.blob.etag),
+    })
+  }
+
+  // Transitional compatibility only. Existing public blobs must still be migrated to a private store.
+  const legacyUrl = getLegacyPublicPdfUrl(video.pdfUrl, videoId)
+  if (!legacyUrl) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+
+  const legacyResponse = await fetch(legacyUrl, {
+    cache: 'no-store',
+    redirect: 'error',
+    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+  })
+  if (!legacyResponse.ok || !legacyResponse.body) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const contentLength = Number(legacyResponse.headers.get('content-length'))
+  return new Response(legacyResponse.body, {
+    status: 200,
+    headers: downloadHeaders(
+      filename,
+      Number.isFinite(contentLength) ? contentLength : null,
+      legacyResponse.headers.get('etag')
+    ),
+  })
+}

--- a/app/api/upload/pdf/route.ts
+++ b/app/api/upload/pdf/route.ts
@@ -1,24 +1,47 @@
 // app/api/upload/pdf/route.ts
 
 import { randomUUID } from 'crypto'
-import { NextResponse } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 import { prisma } from '@/lib/prisma'
 import { put } from '@vercel/blob'
 import sanitizeFilename from 'sanitize-filename'
 import { requireAdminApiAccess } from '@/lib/authz'
+import { requireAgentUploadAccess } from '@/lib/agent-upload-auth'
 
-export const POST = async (request: Request) => {
-  const admin = await requireAdminApiAccess()
-  if (!admin.ok) {
-    return admin.response
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+const MAX_PDF_BYTES = 25 * 1024 * 1024
+const MAX_MULTIPART_BYTES = MAX_PDF_BYTES + 1024 * 1024
+
+async function requirePdfUploadAccess(request: NextRequest) {
+  const agent = requireAgentUploadAccess(request)
+  if (agent.ok) return agent
+
+  return requireAdminApiAccess()
+}
+
+export const POST = async (request: NextRequest) => {
+  const access = await requirePdfUploadAccess(request)
+  if (!access.ok) {
+    return access.response
+  }
+
+  const contentLength = Number(request.headers.get('content-length') ?? '0')
+  if (!Number.isFinite(contentLength) || contentLength < 0 || contentLength > MAX_MULTIPART_BYTES) {
+    return NextResponse.json({ error: 'Upload zu groß' }, { status: 413 })
   }
 
   try {
     const formData = await request.formData()
-    const pdfFile = formData.get('pdf') as File
-    const videoId = formData.get('videoId') as string
+    const pdfFile = formData.get('pdf')
+    const videoId = formData.get('videoId')
 
-    if (!pdfFile || !videoId) {
+    if (
+      !(pdfFile instanceof File) ||
+      typeof videoId !== 'string' ||
+      !/^[A-Za-z0-9_-]{1,128}$/.test(videoId)
+    ) {
       return NextResponse.json({ error: 'PDF oder Video-ID fehlt' }, { status: 400 })
     }
 
@@ -26,28 +49,27 @@ export const POST = async (request: Request) => {
       return NextResponse.json({ error: 'Nur PDF-Dateien sind erlaubt' }, { status: 400 })
     }
 
-    if (pdfFile.size <= 0 || pdfFile.size > 25 * 1024 * 1024) {
+    if (pdfFile.size <= 0 || pdfFile.size > MAX_PDF_BYTES) {
       return NextResponse.json({ error: 'PDF muss zwischen 1 Byte und 25 MB liegen' }, { status: 400 })
     }
 
-    // Original-Dateinamen nehmen und sicher machen
+    if ((await pdfFile.slice(0, 5).text()) !== '%PDF-') {
+      return NextResponse.json({ error: 'Ungültige PDF-Datei' }, { status: 400 })
+    }
+
     let originalName = pdfFile.name
     if (!originalName.toLowerCase().endsWith('.pdf')) {
       originalName += '.pdf'
     }
 
-    // Sichere den Dateinamen (entfernt ungültige Zeichen, Sonderzeichen, etc.)
     const safeFilename = sanitizeFilename(originalName) || 'document.pdf'
-
-    // Eindeutigen, schwer erratbaren Pfad erstellen
     const blobPath = `pdfs/${videoId}/${randomUUID()}-${safeFilename}`
 
-    // Hochladen mit Originalnamen
     const { url } = await put(blobPath, pdfFile, {
       access: 'public',
+      contentType: 'application/pdf',
     })
 
-    // In DB speichern
     await prisma.video.update({
       where: { id: videoId },
       data: { pdfUrl: url },

--- a/app/api/upload/pdf/route.ts
+++ b/app/api/upload/pdf/route.ts
@@ -7,6 +7,7 @@ import { put } from '@vercel/blob'
 import sanitizeFilename from 'sanitize-filename'
 import { requireAdminApiAccess } from '@/lib/authz'
 import { requireAgentUploadAccess } from '@/lib/agent-upload-auth'
+import { buildProtectedPdfUrl } from '@/lib/protected-pdf'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -25,6 +26,14 @@ export const POST = async (request: NextRequest) => {
   const access = await requirePdfUploadAccess(request)
   if (!access.ok) {
     return access.response
+  }
+
+  const privateBlobToken = process.env.BLOB_PRIVATE_READ_WRITE_TOKEN?.trim()
+  if (!privateBlobToken) {
+    return NextResponse.json(
+      { error: 'Private PDF storage is not configured' },
+      { status: 503 }
+    )
   }
 
   const contentLength = Number(request.headers.get('content-length') ?? '0')
@@ -65,18 +74,22 @@ export const POST = async (request: NextRequest) => {
     const safeFilename = sanitizeFilename(originalName) || 'document.pdf'
     const blobPath = `pdfs/${videoId}/${randomUUID()}-${safeFilename}`
 
-    const { url } = await put(blobPath, pdfFile, {
-      access: 'public',
+    const blob = await put(blobPath, pdfFile, {
+      access: 'private',
+      token: privateBlobToken,
       contentType: 'application/pdf',
+      cacheControlMaxAge: 60,
     })
+
+    const protectedUrl = buildProtectedPdfUrl(videoId, safeFilename, blob.pathname)
 
     await prisma.video.update({
       where: { id: videoId },
-      data: { pdfUrl: url },
+      data: { pdfUrl: protectedUrl },
       select: { id: true },
     })
 
-    return NextResponse.json({ pdfUrl: url })
+    return NextResponse.json({ pdfUrl: protectedUrl })
   } catch (error) {
     console.error('PDF Upload Fehler:', error)
     return NextResponse.json({ error: 'Upload fehlgeschlagen' }, { status: 500 })

--- a/lib/protected-pdf.ts
+++ b/lib/protected-pdf.ts
@@ -1,0 +1,78 @@
+const PROTECTED_PDF_PREFIX = '/api/download/pdf/'
+const PRIVATE_BLOB_QUERY_KEY = 'blob'
+
+function safePdfFilename(value: string) {
+  const decoded = (() => {
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return value
+    }
+  })()
+  const basename = decoded.split('/').pop()?.replace(/[\r\n"\\]/g, '').trim() || 'document.pdf'
+  return basename.toLowerCase().endsWith('.pdf') ? basename : `${basename}.pdf`
+}
+
+export function buildProtectedPdfUrl(
+  videoId: string,
+  filename: string,
+  privateBlobPathname?: string
+) {
+  const route = `${PROTECTED_PDF_PREFIX}${encodeURIComponent(videoId)}/${encodeURIComponent(
+    safePdfFilename(filename)
+  )}`
+  if (!privateBlobPathname) return route
+
+  const search = new URLSearchParams({ [PRIVATE_BLOB_QUERY_KEY]: privateBlobPathname })
+  return `${route}?${search.toString()}`
+}
+
+export function toProtectedPdfUrl(videoId: string, pdfUrl: string | null) {
+  if (!pdfUrl) return null
+  if (pdfUrl.startsWith(PROTECTED_PDF_PREFIX)) return pdfUrl
+
+  let filename = 'document.pdf'
+  try {
+    filename = safePdfFilename(new URL(pdfUrl).pathname)
+  } catch {
+    filename = safePdfFilename(pdfUrl)
+  }
+
+  return buildProtectedPdfUrl(videoId, filename)
+}
+
+export function getPrivatePdfBlobPathname(pdfUrl: string, videoId: string) {
+  if (!pdfUrl.startsWith(PROTECTED_PDF_PREFIX)) return null
+
+  const parsed = new URL(pdfUrl, 'https://local.invalid')
+  const pathname = parsed.searchParams.get(PRIVATE_BLOB_QUERY_KEY)
+  if (!pathname) return null
+  if (pathname.includes('..') || pathname.includes('\\') || pathname.includes('://')) return null
+  if (!pathname.startsWith(`pdfs/${videoId}/`)) return null
+  if (!pathname.toLowerCase().endsWith('.pdf')) return null
+  return pathname
+}
+
+export function getLegacyPublicPdfUrl(pdfUrl: string, videoId: string) {
+  if (pdfUrl.startsWith(PROTECTED_PDF_PREFIX)) return null
+
+  try {
+    const parsed = new URL(pdfUrl)
+    if (parsed.protocol !== 'https:' || parsed.port || parsed.username || parsed.password) return null
+    if (!parsed.hostname.endsWith('.public.blob.vercel-storage.com')) return null
+    if (!parsed.pathname.startsWith(`/pdfs/${videoId}/`)) return null
+    if (!parsed.pathname.toLowerCase().endsWith('.pdf')) return null
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+export function getStoredPdfFilename(pdfUrl: string) {
+  try {
+    const parsed = new URL(pdfUrl, 'https://local.invalid')
+    return safePdfFilename(parsed.pathname)
+  } catch {
+    return 'document.pdf'
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@types/canvas-confetti": "^1.6.4",
         "@types/tus-js-client": "^1.8.0",
         "@vercel/analytics": "^1.3.2",
-        "@vercel/blob": "^2.0.0",
+        "@vercel/blob": "2.6.1",
         "@vercel/speed-insights": "^1.1.0",
         "axios": "^1.13.2",
         "canvas-confetti": "^1.9.3",
@@ -985,15 +985,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -6061,19 +6052,160 @@
       }
     },
     "node_modules/@vercel/blob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.0.0.tgz",
-      "integrity": "sha512-oAj7Pdy83YKSwIaMFoM7zFeLYWRc+qUpW3PiDSblxQMnGFb43qs4bmfq7dr/+JIfwhs6PTwe1o2YBwKhyjWxXw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.6.1.tgz",
+      "integrity": "sha512-KTJytw85j1XQBxjN5d6UXI7fIWNQe1jotn4nWN+0hePqLs+Qi1B3jHdQcSKFGF0m2rsy9uhPT6GOXMtHe3qNzg==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@vercel/oidc": "^3.6.1",
         "async-retry": "^1.3.3",
         "is-buffer": "^2.0.5",
         "is-node-process": "^1.2.0",
         "throttleit": "^2.1.0",
-        "undici": "^5.28.4"
+        "undici": "^6.23.0"
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/cli-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-config/-/cli-config-0.2.0.tgz",
+      "integrity": "sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xdg-app-paths": "5",
+        "zod": "4.1.11"
+      }
+    },
+    "node_modules/@vercel/cli-config/node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@vercel/cli-exec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/cli-exec/-/cli-exec-1.0.0.tgz",
+      "integrity": "sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "execa": "5.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vercel/cli-exec/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@vercel/cli-exec/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.8.0.tgz",
+      "integrity": "sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/cli-config": "0.2.0",
+        "@vercel/cli-exec": "1.0.0",
+        "jose": "^5.9.6"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@vercel/speed-insights": {
@@ -9158,7 +9290,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10346,6 +10477,15 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-base64": {
       "version": "3.7.8",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
@@ -11170,7 +11310,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -12588,6 +12727,15 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
+    },
+    "node_modules/os-paths": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/os-paths/-/os-paths-4.4.0.tgz",
+      "integrity": "sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0"
+      }
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
@@ -15708,15 +15856,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -16277,6 +16422,31 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xdg-app-paths": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.5.1.tgz",
+      "integrity": "sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1",
+        "xdg-portable": "^7.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0"
+      }
+    },
+    "node_modules/xdg-portable": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/xdg-portable/-/xdg-portable-7.3.0.tgz",
+      "integrity": "sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-paths": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/canvas-confetti": "^1.6.4",
     "@types/tus-js-client": "^1.8.0",
     "@vercel/analytics": "^1.3.2",
-    "@vercel/blob": "^2.0.0",
+    "@vercel/blob": "2.6.1",
     "@vercel/speed-insights": "^1.1.0",
     "axios": "^1.13.2",
     "canvas-confetti": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "invoices:download": "node scripts/download-invoices.mjs --env-file .env.local",
     "hermes:upload": "node scripts/hermes-upload.mjs",
+    "test:hermes-upload": "node --test scripts/hermes-upload.test.mjs",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/scripts/hermes-upload.mjs
+++ b/scripts/hermes-upload.mjs
@@ -5,9 +5,11 @@ import fs from 'fs'
 import os from 'os'
 import path from 'path'
 import process from 'process'
+import { pathToFileURL } from 'url'
 import * as tus from 'tus-js-client'
 
 const DEFAULT_BASE_URL = 'https://www.price-action-trader.de'
+const MAX_PDF_BYTES = 25 * 1024 * 1024
 
 function loadEnvFile(filePath) {
   if (!fs.existsSync(filePath)) return
@@ -23,19 +25,18 @@ function loadEnvFile(filePath) {
   }
 }
 
-loadEnvFile(path.join(os.homedir(), '.pat-hermes-upload.env'))
-loadEnvFile(path.join(process.cwd(), '.env.hermes-upload.local'))
-
 function printHelp() {
   console.log(`Hermes PAT video uploader
 
 Usage:
   node scripts/hermes-upload.mjs --type daily_review --file "/Volumes/SSD/2026-06/review.mp4"
   node scripts/hermes-upload.mjs --type advanced_content --file lesson.mp4 --title "Liquidity Sweep Entry"
+  node scripts/hermes-upload.mjs --type advanced_content --file lesson.mp4 --pdf slides.pdf
 
 Options:
   --type daily_review|advanced_content  Required target workflow.
   --file <path>                         Required local video path.
+  --pdf <path>                          Optional PDF slides; attached to the lesson (max 25 MB).
   --title <title>                       Optional; inferred from filename if omitted.
   --date YYYY-MM-DD                     Optional; inferred from filename or file mtime.
   --month YYYY-MM                       Optional; inferred from date.
@@ -56,7 +57,7 @@ Environment:
 `)
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = {}
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]
@@ -130,6 +131,65 @@ function contentTypeFor(filePath) {
   return 'video/mp4'
 }
 
+export function validatePdfFile(filePath) {
+  const resolvedPath = path.resolve(String(filePath))
+  if (!fs.existsSync(resolvedPath)) throw new Error(`PDF not found: ${resolvedPath}`)
+
+  const stats = fs.statSync(resolvedPath)
+  if (!stats.isFile()) throw new Error(`PDF is not a file: ${resolvedPath}`)
+  if (path.extname(resolvedPath).toLowerCase() !== '.pdf') {
+    throw new Error(`PDF must use the .pdf extension: ${resolvedPath}`)
+  }
+  if (stats.size <= 0 || stats.size > MAX_PDF_BYTES) {
+    throw new Error('PDF must be between 1 byte and 25 MB')
+  }
+
+  const fd = fs.openSync(resolvedPath, 'r')
+  try {
+    const header = Buffer.alloc(5)
+    const bytesRead = fs.readSync(fd, header, 0, header.length, 0)
+    if (bytesRead !== header.length || header.toString('ascii') !== '%PDF-') {
+      throw new Error(`Invalid PDF file: ${resolvedPath}`)
+    }
+  } finally {
+    fs.closeSync(fd)
+  }
+
+  return { filePath: resolvedPath, stats }
+}
+
+export async function uploadPdf(baseUrl, token, pdfPath, videoId) {
+  const { filePath } = validatePdfFile(pdfPath)
+  const formData = new FormData()
+  formData.append('videoId', String(videoId))
+  formData.append(
+    'pdf',
+    new Blob([fs.readFileSync(filePath)], { type: 'application/pdf' }),
+    path.basename(filePath)
+  )
+
+  const res = await fetch(`${baseUrl.replace(/\/$/, '')}/api/upload/pdf`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  })
+  const text = await res.text()
+  let data = null
+  try {
+    data = text ? JSON.parse(text) : null
+  } catch {
+    data = null
+  }
+  if (!res.ok) {
+    throw new Error(`PDF upload failed (${res.status}): ${text}`)
+  }
+  if (!data?.pdfUrl) {
+    throw new Error(`PDF upload returned no pdfUrl: ${text}`)
+  }
+
+  return { videoId, filename: path.basename(filePath), pdfUrl: data.pdfUrl }
+}
+
 async function postJson(baseUrl, token, payload) {
   const res = await fetch(`${baseUrl.replace(/\/$/, '')}/api/agent/uploads`, {
     method: 'POST',
@@ -180,6 +240,9 @@ function uploadTus(filePath, stats, prepared) {
 }
 
 async function main() {
+  loadEnvFile(path.join(os.homedir(), '.pat-hermes-upload.env'))
+  loadEnvFile(path.join(process.cwd(), '.env.hermes-upload.local'))
+
   const args = parseArgs(process.argv.slice(2))
   if (args.help) {
     printHelp()
@@ -196,6 +259,7 @@ async function main() {
   if (!fs.existsSync(filePath)) throw new Error(`File not found: ${filePath}`)
   const stats = fs.statSync(filePath)
   if (!stats.isFile()) throw new Error(`Not a file: ${filePath}`)
+  const pdfPath = args.pdf ? validatePdfFile(args.pdf).filePath : null
 
   const baseUrl = args['base-url'] || process.env.PAT_UPLOAD_BASE_URL || DEFAULT_BASE_URL
   const token = args.token || process.env.PAT_UPLOAD_TOKEN || process.env.AGENT_UPLOAD_TOKEN
@@ -233,20 +297,27 @@ async function main() {
 
   if (prepared.uploadedAt && !args.forceUpload) {
     console.log('Already marked uploaded. Use --force-upload to upload again to the same Bunny video.')
-    return
+  } else {
+    await uploadTus(filePath, stats, prepared)
+    const finalized = await postJson(baseUrl, token, {
+      action: 'finalize',
+      idempotencyKey,
+      videoId: prepared.video.id,
+      bunnyGuid: prepared.video.bunnyGuid,
+    })
+    console.log(JSON.stringify({ finalized, links: prepared.links }, null, 2))
   }
 
-  await uploadTus(filePath, stats, prepared)
-  const finalized = await postJson(baseUrl, token, {
-    action: 'finalize',
-    idempotencyKey,
-    videoId: prepared.video.id,
-    bunnyGuid: prepared.video.bunnyGuid,
-  })
-  console.log(JSON.stringify({ finalized, links: prepared.links }, null, 2))
+  if (pdfPath) {
+    const pdf = await uploadPdf(baseUrl, token, pdfPath, prepared.video.id)
+    console.log(JSON.stringify({ pdf }, null, 2))
+  }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error)
-  process.exit(1)
-})
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (isMain) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}

--- a/scripts/hermes-upload.test.mjs
+++ b/scripts/hermes-upload.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { once } from 'node:events'
+
+import { parseArgs, uploadPdf, validatePdfFile } from './hermes-upload.mjs'
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pat-hermes-upload-test-'))
+}
+
+function writePdf(dir, name = 'slides.pdf') {
+  const filePath = path.join(dir, name)
+  fs.writeFileSync(filePath, '%PDF-1.4\n1 0 obj\n<<>>\nendobj\n%%EOF\n')
+  return filePath
+}
+
+test('parseArgs accepts an optional PDF path', () => {
+  const args = parseArgs([
+    '--type',
+    'advanced_content',
+    '--file',
+    'lesson.mp4',
+    '--pdf',
+    'slides.pdf',
+  ])
+
+  assert.equal(args.type, 'advanced_content')
+  assert.equal(args.file, 'lesson.mp4')
+  assert.equal(args.pdf, 'slides.pdf')
+})
+
+test('validatePdfFile accepts PDFs and rejects files without a PDF signature', () => {
+  const dir = makeTempDir()
+  try {
+    const validPdf = writePdf(dir)
+    const validated = validatePdfFile(validPdf)
+    assert.equal(validated.filePath, validPdf)
+    assert.ok(validated.stats.size > 0)
+
+    const invalidPdf = path.join(dir, 'fake.pdf')
+    fs.writeFileSync(invalidPdf, 'not a pdf')
+    assert.throws(() => validatePdfFile(invalidPdf), /Invalid PDF file/)
+
+    const oversizedPdf = path.join(dir, 'oversized.pdf')
+    fs.writeFileSync(oversizedPdf, '%PDF-')
+    fs.truncateSync(oversizedPdf, 25 * 1024 * 1024 + 1)
+    assert.throws(() => validatePdfFile(oversizedPdf), /between 1 byte and 25 MB/)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('uploadPdf sends authenticated multipart data and returns the lesson PDF URL', async () => {
+  const dir = makeTempDir()
+  const pdfPath = writePdf(dir, 'NDOG & NWOG Slides.pdf')
+  let requestData = null
+
+  const server = http.createServer(async (req, res) => {
+    const chunks = []
+    for await (const chunk of req) chunks.push(chunk)
+    requestData = {
+      method: req.method,
+      url: req.url,
+      authorization: req.headers.authorization,
+      contentType: req.headers['content-type'],
+      body: Buffer.concat(chunks),
+    }
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify({ pdfUrl: 'https://example.test/pdfs/video_123/slides.pdf' }))
+  })
+
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+
+  try {
+    const address = server.address()
+    assert.ok(address && typeof address === 'object')
+    const result = await uploadPdf(
+      `http://127.0.0.1:${address.port}`,
+      'agent-test-token',
+      pdfPath,
+      'video_123'
+    )
+
+    assert.equal(result.videoId, 'video_123')
+    assert.equal(result.filename, 'NDOG & NWOG Slides.pdf')
+    assert.equal(result.pdfUrl, 'https://example.test/pdfs/video_123/slides.pdf')
+    assert.equal(requestData.method, 'POST')
+    assert.equal(requestData.url, '/api/upload/pdf')
+    assert.equal(requestData.authorization, 'Bearer agent-test-token')
+    assert.match(requestData.contentType, /^multipart\/form-data; boundary=/)
+
+    const body = requestData.body.toString('utf8')
+    assert.match(body, /name="videoId"/)
+    assert.match(body, /video_123/)
+    assert.match(body, /filename="NDOG & NWOG Slides\.pdf"/)
+    assert.match(body, /%PDF-1\.4/)
+  } finally {
+    server.close()
+    await once(server, 'close')
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Adds optional PDF attachment to Hermes lesson uploads, validates and stores PDFs privately, and serves them through an entitlement-protected download route. Validated with 3/3 Hermes upload tests and targeted ESLint. The production build compiles and passes TypeScript; isolated prerender requires the unavailable Clerk publishable key.